### PR TITLE
[Node-AzureSearch] Update to botbuilder 3.5.1 and Library creation syntax updates

### DIFF
--- a/Node/demo-Search/.vscode/launch.json
+++ b/Node/demo-Search/.vscode/launch.json
@@ -18,6 +18,7 @@
                 "NODE_ENV": "development",
                 "MICROSOFT_APP_ID": "",
                 "MICROSOFT_APP_PASSWORD": ""
+                "BOT": "RealEstateBot"
             },
             "externalConsole": false,
             "sourceMaps": false,

--- a/Node/demo-Search/README.md
+++ b/Node/demo-Search/README.md
@@ -15,7 +15,7 @@ Content is modeled as a catalog of items where each item has several attributes 
 
 The minimum prerequisites to run this sample are:
 * Latest Node.js with NPM. Download it from [here](https://nodejs.org/en/download/).
-* The Bot Framework Emulator. To install the Bot Framework Emulator, download it from [here](https://aka.ms/bf-bc-emulator). Please refer to [this documentation article](https://docs.botframework.com/en-us/csharp/builder/sdkreference/gettingstarted.html#emulator) to know more about the Bot Framework Emulator.
+* The Bot Framework Emulator. To install the Bot Framework Emulator, download it from [here](https://emulator.botframework.com/). Please refer to [this documentation article](https://github.com/microsoft/botframework-emulator/wiki/Getting-Started) to know more about the Bot Framework Emulator.
 * **[Recommended]** Visual Studio Code for IntelliSense and debugging, download it from [here](https://code.visualstudio.com/) for free.
 
 ### Azure Search
@@ -28,9 +28,9 @@ The samples use [Azure Search](https://azure.microsoft.com/en-us/services/search
 
 The samples include a bot library that contains a few different dialogs that are ready to use and can be customized as needed. The library is defined as the [SearchDialogLibrary](SearchDialogLibrary/index.js) module and it includes two main dialogs that can be used directly:
 
-* [Root dialog](SearchDialogLibrary/index.js#L39) offers a complete keyword search + refine experience over a search index, and uses the other search dialogs as building blocks. Users can explore the catalog by refining (using facets) and by using keyword search. They can also select items and review their selection. At the end of this dialog a list of one or more selected items is returned.
+* [Root dialog](SearchDialogLibrary/index.js#L35) offers a complete keyword search + refine experience over a search index, and uses the other search dialogs as building blocks. Users can explore the catalog by refining (using facets) and by using keyword search. They can also select items and review their selection. At the end of this dialog a list of one or more selected items is returned.
 
-* [Refine dialog](SearchDialogLibrary/index.js#L155) helps users pick a refiner (facet). It's a simple wrapper around a "choice" prompt dialog to ensure you don't prompt users for a field you already refined on.
+* [Refine dialog](SearchDialogLibrary/index.js#L151) helps users pick a refiner (facet). It's a simple wrapper around a "choice" prompt dialog to ensure you don't prompt users for a field you already refined on.
 
 ### Samples
 
@@ -68,11 +68,11 @@ We included two samples here:
 
 ### Usage
 
-In order to use the library you need to create an instance of it using the module's `create()` function and specify a few parameters that provides the search implementation and some level of customization for the search experience. Then, you register the returned library object with [`bot.use()`](https://docs.botframework.com/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot.html#use) and trigger the dialogs with `session.beginDialog()`.
+In order to use the library you need to create an instance of it using the module's `create()` function and specify parameters that provides the search implementation and some level of customization for the search experience. Then, you register the returned library object with [`bot.use()`](https://docs.botframework.com/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot.html#use) and trigger the dialogs with `SearchModule.begin(session)` or `SearchModule.refine(session, arguments)`.
 
 ````JavaScript
-var SearchDialogLibrary = require('./SearchDialogLibrary');
-var mySearchLibrary = SearchDialogLibrary.create('my-search', {
+var SearchLibrary = require('./SearchDialogLibrary');
+var mySearchLibrary = SearchLibrary.create({
     multipleSelection: true,
     search: (query) => { return mySearchClient.search(query).then(mapResultSetFunction); },
     refiners: ['type', 'region']
@@ -84,7 +84,7 @@ bot.use(mySearchLibrary);
 bot.dialog('/', [
     function (session) {
         // Triger search dialog
-        session.beginDialog('my-search:/');
+        SearchLibrary.begin(session);
     },
     function (session, args) {
         // Display selected results
@@ -97,11 +97,10 @@ bot.dialog('/', [
 
 #### Parameters and Settings
 
-> SearchDialogLibrary.create(libraryId:string, settings):Library
+> SearchDialogLibrary.create(settings):Library
 
-* `libraryId` is required, defines the library name and the prefix you'll need to use when calling `session.beginDialog('libraryId:/')`;
-* `settings` is also required. The only detail really needed is the `search` function.
-    * `search` is a required function. Accepts a `query` object and must return a Promise with a [`SearchResults`](SearchDialogLibrary/index.d.ts#L28-L31) object (See [Implementing a new Search Provider](#implementing-a-new-search-provider) below).
+* `settings` is required. The only detail really needed is the `search` function.
+    * `search` is a required function. Accepts a `query` object and must return a Promise with a [`ISearchResults`](SearchDialogLibrary/index.d.ts#L30-L33) object (See [Implementing a new Search Provider](#implementing-a-new-search-provider) below).
     * `multipleSelection` (optional - default=true). Boolean value indicating if multiple selection should be allowed. When `false`, the dialog will end as soon as an item is selected.
     * `pageSize` (optional - default=5). Page size parameter passed to the search function.
     * `refiners`. (optional). Array of strings containing the facets/refiners allowed to use.
@@ -119,7 +118,7 @@ In order to integrate the Search Dialog library with a new search engine, you ne
 function search: (query: Query) => PromiseLike<SearchResults>
 ````
 
-Input [`query`](SearchDialogLibrary/index.d.ts#L20-L26) object with the following fields:
+Input [`query`](SearchDialogLibrary/index.d.ts#L22-L28) object with the following fields:
 
 * `searchText`: string
 
@@ -141,7 +140,7 @@ Input [`query`](SearchDialogLibrary/index.d.ts#L20-L26) object with the followin
 
   An array containing the facets you want to obtain possible values for. The search function should take this into account and proceed to *search* or *retrieve sub-categories* for the current search string.
 
-The `search` must return a `Promise`, that once fulfilled, should resolve to a [`SearchResults`](SearchDialogLibrary/index.d.ts#L28-L31) object. This object must have the following fields:
+The `search` must return a `Promise`, that once fulfilled, should resolve to a [`ISearchResults`](SearchDialogLibrary/index.d.ts#L30-L33) object. This object must have the following fields:
 
 * `facets`: Array of `Facet`. Each Facet object contains a `key` field with the name of the facet and an `options` field with an array of possible values. Each value is a tuple of `key` representing a possible facet value, and a `count` field with the total items for that facet.
 

--- a/Node/demo-Search/SearchDialogLibrary/index.d.ts
+++ b/Node/demo-Search/SearchDialogLibrary/index.d.ts
@@ -1,53 +1,55 @@
-import { Library } from "botbuilder";
+import { Library, Session } from "botbuilder";
 
-// Exported functions
-export function create(libraryId: string, settings: SearchDialogSettings): Library;
+// exported functions
+export function create(settings: ISearchDialogSettings): Library;
+export function begin(session: Session, args?: any): void;
+export function refine(session: Session, args?: any): void;
 export function defaultResultsMapper(itemMap: ItemMapper): SearchResultsMapper;
 
-declare type ItemMapper = (input: any) => SearchHit;
-declare type SearchResultsMapper = (providerResults: SearchResults) => SearchResults;
+declare type ItemMapper = (input: any) => ISearchHit;
+declare type SearchResultsMapper = (providerResults: ISearchResults) => ISearchResults;
 declare type RefineFormatter = (refiners: Array<string>) => any;
 
-// Entities
-export interface SearchDialogSettings {
-  search: (query: Query) => PromiseLike<SearchResults>;
+// entities
+export interface ISearchDialogSettings {
+  search: (query: IQuery) => PromiseLike<ISearchResults>;
   pageSize?: number;
   multipleSelection?: boolean;
   refiners?: Array<string>;
   refineFormatter?: RefineFormatter;
 }
 
-export interface Query {
+export interface IQuery {
   searchText: string;
   pageSize: number;
   pageNumber: number;
-  filters: Array<FacetFilter>;
+  filters: Array<IFacetFilter>;
   facets: Array<string>;
 }
 
-export interface SearchResults {
-  facets: Array<Facet>;
-  results: Array<SearchHit>
+export interface ISearchResults {
+  facets: Array<IFacet>;
+  results: Array<ISearchHit>;
 }
 
-export interface SearchHit {
+export interface ISearchHit {
   key: string;
   title: string;
   description: string;
-  imageUrl?: string
+  imageUrl?: string;
 }
 
-export interface FacetFilter {
+export interface IFacetFilter {
   key: string;
   value: any;
 }
 
-export interface Facet {
+export interface IFacet {
   key: string;
-  options: Array<FacetValue>;
+  options: Array<IFacetValue>;
 }
 
-export interface FacetValue {
+export interface IFacetValue {
   value: string;
   count: number;
 }

--- a/Node/demo-Search/SearchDialogLibrary/package.json
+++ b/Node/demo-Search/SearchDialogLibrary/package.json
@@ -6,7 +6,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "botbuilder": "^3.2.3",
-    "lodash": "^4.15.0"
+    "botbuilder": "^3.5.1",
+    "lodash": "^4.17.4"
   }
 }

--- a/Node/demo-Search/SearchProviders/azure-search.js
+++ b/Node/demo-Search/SearchProviders/azure-search.js
@@ -47,7 +47,7 @@ function create(serviceName, serviceKey, index) {
                 });
             });
         }
-    }
+    };
 }
 
 // Helpers

--- a/Node/demo-Search/package.json
+++ b/Node/demo-Search/package.json
@@ -9,12 +9,12 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^3.4.6",
-    "botbuilder": "^3.2.3",
-    "lodash": "^4.15.0",
+    "bluebird": "^3.4.7",
+    "botbuilder": "^3.5.1",
+    "lodash": "^4.17.4",
     "lorem-ipsum": "^1.0.3",
     "node-uuid": "^1.4.7",
-    "request": "^2.74.0",
-    "restify": "^4.1.1"
+    "request": "^2.79.0",
+    "restify": "^4.3.0"
   }
 }


### PR DESCRIPTION
- Update to botbuilder 3.5.1 and new library syntax  …
  - Remove libraryId parameter when creating libraries, instead return a clone
  - Add `begin` and `refine` methods to module, for triggering search dialogs
  - Update syntax to v3.5 style
- TypeScript definitions updated
- README Updates