### PR TITLE
Fix service name for QNA_CONFIGURATION for QnA Maker sample in typescript

### DIFF
--- a/samples/javascript_typescript/11.qnamaker/src/index.ts
+++ b/samples/javascript_typescript/11.qnamaker/src/index.ts
@@ -32,7 +32,7 @@ const DEV_ENVIRONMENT = 'development';
 // Bot name as defined in .bot file or from runtime.
 // See https://aka.ms/about-bot-file to learn more about .bot files.
 const BOT_CONFIGURATION = (process.env.NODE_ENV || DEV_ENVIRONMENT);
-const QNA_CONFIGURATION = 'qnamakerService';
+const QNA_CONFIGURATION = 'FAQ';
 
 // Get bot endpoint and QnAMaker configuration by service name.
 const endpointConfig = <IEndpointService>botConfig.findServiceByNameOrId(BOT_CONFIGURATION);


### PR DESCRIPTION
The QNA_CONFIGURATION service name is invalid, this causes the error `TypeError: Cannot read property 'kbId' of null`
<img width="800" alt="screenshot_104" src="https://user-images.githubusercontent.com/2738891/46371477-de15db80-c65e-11e8-994c-8dfc4b9d098a.png">
