### PR TITLE
[typescript][02.echo with counter] Fixed minor typos for README

### DIFF
--- a/samples/javascript_typescript/02.echobot-with-counter/README.MD
+++ b/samples/javascript_typescript/02.echobot-with-counter/README.MD
@@ -9,15 +9,15 @@ This sample shows how to create a simple echo bot with state. The bot maintains 
     ```bash
     cd samples/javascript_typescript/02.echobot-with-counter
     ```
-- [Optional] Update the .env file under samples/javascript_typescript/02.echobot-with-counter with your botFileSecret
-    For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the .env file under `samples/javascript_typescript/02.echobot-with-counter` with your `botFileSecret`.
+   For Azure Bot Service bots, you can find the `botFileSecret` under application settings.
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
     Alternatively you can also use nodemon via
     ```bash
-    npm i & npm run watch
+    npm i && npm run watch
     ```
 
 ## Prerequisite
@@ -30,12 +30,12 @@ In order to run this sample, you must have TypeScript installed.  To install Typ
 # Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 
-- Install the Bot Framework emulator from [here](https://aka.ms/botframework-emulator)
+- Install the Bot Framework emulator from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
 
 ## Connect to bot using Bot Framework Emulator **V4**
 - Launch Bot Framework Emulator
-- File -> Open Bot Configuration and navigate to samples/javascript_typescript/02.echobot-with-state folder
-- Select echobot-with-counter.bot file
+- File -> Open Bot Configuration and navigate to `samples/javascript_typescript/02.echobot-with-state` folder
+- Select `echobot-with-counter.bot` file
 
 # Bot state
 A key to good bot design is to track the context of a conversation, so that your bot remembers things like the answers to previous questions. Depending on what your bot is used for, you may even need to keep track of conversation state or store user related information for longer than the lifetime of one given conversation.

--- a/samples/javascript_typescript/02.echobot-with-counter/README.MD
+++ b/samples/javascript_typescript/02.echobot-with-counter/README.MD
@@ -49,15 +49,7 @@ In this example, the bot's state is used to track number of messages.
     - User properties can be used for many purposes, such as determining where the user's prior conversation left off or simply greeting a returning user by name. If you store a user's preferences, you can use that information to customize the conversation the next time you chat. For example, you might alert the user to a news article about a topic that interests her, or alert a user when an appointment becomes available. You should clear them if the bot receives a delete user data activity.
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on.
-
-To install all Bot Builder tools -
-
-Ensure you have [Node.js](https://nodejs.org/) version 8.5 or higher
-
-```bash
-npm i -g msbot chatdown ludown qnamaker luis-apis botdispatch luisgen
-```
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
 
 To clone this bot, run
 ```


### PR DESCRIPTION
## Proposed Changes
- Minor changes to typos and minimal structural changes.
- Changed `&` to `&&` since only one ampersand makes the commands run asynchronously thus fail due to `npm start` being executed **before** `npm i` can finish installing the dependencies.