### PR TITLE
[nodejs][01.console echo] Fixed minor typos for README 

### DIFF
--- a/samples/javascript_nodejs/01.console-echo/README.md
+++ b/samples/javascript_nodejs/01.console-echo/README.md
@@ -11,7 +11,7 @@ This sample shows how to create a simple echo bot that you can talk to from the 
     ```
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
 
 # Testing the bot 

--- a/samples/javascript_nodejs/01.console-echo/consoleAdapter.js
+++ b/samples/javascript_nodejs/01.console-echo/consoleAdapter.js
@@ -39,7 +39,7 @@ const console = require('console');
 class ConsoleAdapter extends botbuilderCore.BotAdapter {
     /**
      * Creates a new ConsoleAdapter instance.
-     * @param reference (Optional) reference used to customize the address information of activites sent from the adapter.
+     * @param reference (Optional) reference used to customize the address information of activities sent from the adapter.
      */
     constructor(reference) {
         super();


### PR DESCRIPTION
## Proposed Changes
- Changed `&` to `&&` since only one ampersand makes the commands run asynchronously thus fail due to `npm start` being executed **before** `npm i` can finish installing the dependencies.