### PR TITLE
[netcore][51.cafe-bot] Fix string template for QnADialog.cs

### DIFF
--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/QnA/QnADialog.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/QnA/QnADialog.cs
@@ -38,7 +38,7 @@ namespace Microsoft.BotBuilderSamples
             {
                 // No answer found.
                 await dc.Context.SendActivityAsync("I'm still learning... Sorry, I do not know how to help you with that.");
-                await dc.Context.SendActivityAsync("Follow[this link](https://www.bing.com/search?q=${dc.context.activity.text}) to search the web!");
+                await dc.Context.SendActivityAsync($"Follow[this link](https://www.bing.com/search?q={dc.Context.Activity.Text}) to search the web!");
             }
             else
             {


### PR DESCRIPTION
## Proposed Changes
[Line 41](https://github.com/Microsoft/BotBuilder-Samples/blob/89739c630222d978c32fcf505c20bf74bb8a9abc/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/QnA/QnADialog.cs#L41) in `QnADialog.cs` of sample `51.cafe-bot` contains string template in JS style instead of C#.
## Testing
The bot will start to output the message as intended.