### PR TITLE
[DotNet][51.cafe-bot] Fix deploy to Azure

### DIFF
--- a/samples/csharp_dotnetcore/51.cafe-bot/CafeBot.csproj
+++ b/samples/csharp_dotnetcore/51.cafe-bot/CafeBot.csproj
@@ -1,9 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
 	  <CodeAnalysisRuleSet>BotBuilder.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />


### PR DESCRIPTION
Fixes #178 

## Proposed Changes
Add the item group configuration to copy all the .bot files when deploying to Azure

## Testing
![image](https://user-images.githubusercontent.com/42191764/53439522-f5c07880-39e0-11e9-8af7-544f5575337d.png)
