### PR TITLE
Add LUIS as a service

### DIFF
--- a/samples/csharp_dotnetcore/13.basic-bot/Dialogs/MainDialog.cs
+++ b/samples/csharp_dotnetcore/13.basic-bot/Dialogs/MainDialog.cs
@@ -16,12 +16,15 @@ namespace Microsoft.BotBuilderSamples
     {
         protected readonly IConfiguration _configuration;
         protected readonly ILogger _logger;
+        private readonly LuisService _luisService;
 
-        public MainDialog(IConfiguration configuration, ILogger<MainDialog> logger)
+
+        public MainDialog(LuisService luisService, IConfiguration configuration, ILogger<MainDialog> logger)
             : base(nameof(MainDialog))
         {
             _configuration = configuration;
             _logger = logger;
+            _luisService = luisService;
 
             AddDialog(new TextPrompt(nameof(TextPrompt)));
             AddDialog(new BookingDialog());
@@ -38,7 +41,7 @@ namespace Microsoft.BotBuilderSamples
 
         private async Task<DialogTurnResult> IntroStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(_configuration["LuisAppId"]) || string.IsNullOrEmpty(_configuration["LuisAPIKey"]) || string.IsNullOrEmpty(_configuration["LuisAPIHostName"]))
+            if (_luisService.Services == null)
             {
                 await stepContext.Context.SendActivityAsync(
                     MessageFactory.Text("NOTE: LUIS is not configured. To enable all capabilities, add 'LuisAppId', 'LuisAPIKey' and 'LuisAPIHostName' to the appsettings.json file."), cancellationToken);
@@ -50,7 +53,7 @@ namespace Microsoft.BotBuilderSamples
         private async Task<DialogTurnResult> ActStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             // Call LUIS and gather any potential booking details.
-            var bookingDetails = await LuisHelper.ExecuteLuisQuery(_configuration, _logger, stepContext.Context, cancellationToken);
+            var bookingDetails = await LuisHelper.ExecuteLuisQuery(_luisService, _logger, stepContext.Context, cancellationToken);
 
             // In this sample we only have a single Intent we are concerned with. However, typically a scneario
             // will have multiple different Intents each corresponding to starting a different child Dialog.

--- a/samples/csharp_dotnetcore/13.basic-bot/LuisHelper.cs
+++ b/samples/csharp_dotnetcore/13.basic-bot/LuisHelper.cs
@@ -14,34 +14,26 @@ namespace Microsoft.BotBuilderSamples
 {
     public static class LuisHelper
     {
-        public static async Task<BookingDetails> ExecuteLuisQuery(IConfiguration configuration, ILogger logger, ITurnContext turnContext, CancellationToken cancellationToken)
+        public static readonly string LuisConfiguration = "LUIS_APPLICATION_NAME";
+
+        public static async Task<BookingDetails> ExecuteLuisQuery(LuisService luisService, ILogger logger, ITurnContext turnContext, CancellationToken cancellationToken)
         {
             var bookingDetails = new BookingDetails();
-
             try
-            {
-                // Create the LUIS settings from configuration.
-                var luisApplication = new LuisApplication(
-                    configuration["LuisAppId"],
-                    configuration["LuisAPIKey"],
-                    "https://" + configuration["LuisAPIHostName"]
-                );
+            { 
+            // The actual call to LUIS
+            var luisResult = await luisService.Services[LuisConfiguration].RecognizeAsync(turnContext, cancellationToken);
 
-                var recognizer = new LuisRecognizer(luisApplication);
-
-                // The actual call to LUIS
-                var recognizerResult = await recognizer.RecognizeAsync(turnContext, cancellationToken);
-
-                var (intent, score) = recognizerResult.GetTopScoringIntent();
+            var (intent, score) = luisResult.GetTopScoringIntent();
                 if (intent == "Book_flight")
                 {
                     // We need to get the result from the LUIS JSON which at every level returns an array.
-                    bookingDetails.Destination = recognizerResult.Entities["To"]?.FirstOrDefault()?["Airport"]?.FirstOrDefault()?.FirstOrDefault()?.ToString();
-                    bookingDetails.Origin = recognizerResult.Entities["From"]?.FirstOrDefault()?["Airport"]?.FirstOrDefault()?.FirstOrDefault()?.ToString();
+                    bookingDetails.Destination = luisResult.Entities["To"]?.FirstOrDefault()?["Airport"]?.FirstOrDefault()?.FirstOrDefault()?.ToString();
+                    bookingDetails.Origin = luisResult.Entities["From"]?.FirstOrDefault()?["Airport"]?.FirstOrDefault()?.FirstOrDefault()?.ToString();
 
                     // This value will be a TIMEX. And we are only interested in a Date so grab the first result and drop the Time part.
                     // TIMEX is a format that represents DateTime expressions that include some ambiguity. e.g. missing a Year.
-                    bookingDetails.TravelDate = recognizerResult.Entities["datetime"]?.FirstOrDefault()?["timex"]?.FirstOrDefault()?.ToString().Split('T')[0];
+                    bookingDetails.TravelDate = luisResult.Entities["datetime"]?.FirstOrDefault()?["timex"]?.FirstOrDefault()?.ToString().Split('T')[0];
                 }
             }
             catch (Exception e)

--- a/samples/csharp_dotnetcore/13.basic-bot/LuisService.cs
+++ b/samples/csharp_dotnetcore/13.basic-bot/LuisService.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Microsoft.Bot.Builder.AI.Luis;
+using Microsoft.Extensions.Configuration;
+using System;
+
+namespace Microsoft.BotBuilderSamples
+{   
+    public class LuisService
+    {
+        public LuisService(IConfiguration configuration)
+        {
+            if (string.IsNullOrEmpty(configuration["LuisAppId"]) || string.IsNullOrEmpty(configuration["LuisAPIKey"]) || string.IsNullOrEmpty(configuration["LuisAPIHostName"]))
+            {
+                return;
+            }
+        
+            var luisApplication = new LuisApplication(
+              configuration["LuisAppId"],
+              configuration["LuisAPIKey"],
+              "https://" + configuration["LuisAPIHostName"]
+             );            
+            var recognizer = new LuisRecognizer(luisApplication);
+            this.Services = new Dictionary<string, LuisRecognizer>();
+            var luisName = configuration["luisAppName"];
+            this.Services.Add(luisName, recognizer);
+        }
+
+        public Dictionary<string, LuisRecognizer> Services { get; }
+    }
+}

--- a/samples/csharp_dotnetcore/13.basic-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/13.basic-bot/Startup.cs
@@ -38,6 +38,9 @@ namespace Microsoft.BotBuilderSamples
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, DialogAndWelcomeBot<MainDialog>>();
+
+            // Add LuisService singleton from appsettings file.
+            services.AddSingleton<LuisService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/csharp_dotnetcore/13.basic-bot/appsettings.json
+++ b/samples/csharp_dotnetcore/13.basic-bot/appsettings.json
@@ -3,5 +3,7 @@
   "MicrosoftAppPassword": "",
   "LuisAppId": "",
   "LuisAPIKey": "",
-  "LuisAPIHostName": ""
+  "LuisAPIHostName": "",
+  "luisAppName": ""
 }
+


### PR DESCRIPTION
## Proposed Changes
We update the Basic-bot Sample to manages LUIS as a service by adding a `LuisServices` custom class that is registered in the startup class. 

Now in the class `LuisHelper` we can access the LUIS by configuring the LUIS name and receive the LUIS service as a parameter in the method `ExecuteLuisQuery`

![image](https://user-images.githubusercontent.com/37461749/54531817-fa83a700-4964-11e9-8666-3cbac0223521.png)

We updated the logic keeping the objective of the sample to be simple and the user will run the Bot wit or without a LUIS service configured. 

## Testing
Now the Bot can be tested without a LUIS service configures. by adding a Bot file with the endpoint. 
![image](https://user-images.githubusercontent.com/37461749/54530787-79c3ab80-4962-11e9-9141-dacee43e1c5a.png)

Also, it can be tested with the LUIS service configured
![image](https://user-images.githubusercontent.com/37461749/54531101-42093380-4963-11e9-8ffc-37f2e57f4294.png)

