### PR TITLE
[JS sample] Add CoreBot with Application-Insights 

### DIFF
--- a/samples/javascript_nodejs/21.corebot-app-insights/.env
+++ b/samples/javascript_nodejs/21.corebot-app-insights/.env
@@ -1,0 +1,5 @@
+MicrosoftAppId=
+MicrosoftAppPassword=
+LuisAppId=
+LuisAPIKey=
+LuisAPIHostName=

--- a/samples/javascript_nodejs/21.corebot-app-insights/.env
+++ b/samples/javascript_nodejs/21.corebot-app-insights/.env
@@ -3,3 +3,4 @@ MicrosoftAppPassword=
 LuisAppId=
 LuisAPIKey=
 LuisAPIHostName=
+InstrumentationKey=

--- a/samples/javascript_nodejs/21.corebot-app-insights/.eslintrc.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+    "extends": "standard",
+    "rules": {    
+        "semi": [2, "always"],
+        "indent": [2, 4],
+        "no-return-await": 0,
+        "space-before-function-paren": [2, {
+            "named": "never",
+            "anonymous": "never",
+            "asyncArrow": "always"
+        }],
+        "template-curly-spacing": [2, "always"]
+    },
+    "env": {
+        "commonjs": true,
+        "node": true,
+        "mocha": true     
+    }
+};

--- a/samples/javascript_nodejs/21.corebot-app-insights/.gitignore
+++ b/samples/javascript_nodejs/21.corebot-app-insights/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.nyc_output/
+.vscode/
+.env

--- a/samples/javascript_nodejs/21.corebot-app-insights/README.md
+++ b/samples/javascript_nodejs/21.corebot-app-insights/README.md
@@ -1,0 +1,104 @@
+# CoreBot with Application Insights
+
+Bot Framework v4 core bot sample.
+
+This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to:
+
+- Use [LUIS](https://www.luis.ai) to implement core AI capabilities
+- Implement a multi-turn conversation using Dialogs
+- Handle user interruptions for such things as `Help` or `Cancel`
+- Prompt for and validate requests for information from the user
+- Use [Application Insights](https://docs.microsoft.com/azure/azure-monitor/app/cloudservices) to monitor your bot
+
+## Prerequisites
+
+This sample **requires** prerequisites in order to run.
+
+### Overview
+
+This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to implement language understanding 
+and [Application Insights](https://docs.microsoft.com/azure/azure-monitor/app/cloudservices), an extensible Application Performance Management (APM) service for web developers on multiple platforms.
+
+- [Node.js](https://nodejs.org) version 10.14 or higher
+
+    ```bash
+    # determine node version
+    node --version
+    ```
+
+### Create a LUIS Application to enable language understanding
+
+The LUIS model for this example can be found under `CognitiveModels/FlightBooking.json` and the LUIS language model setup, training, and application configuration steps can be found [here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-luis?view=azure-bot-service-4.0&tabs=cs).
+
+Once you created the LUIS model, update `appsettings.json` with your `LuisAppId`, `LuisAPIKey` and `LuisAPIHostName`.
+
+```json
+  "LuisAppId": "Your LUIS App Id",
+  "LuisAPIKey": "Your LUIS Subscription key here",
+  "LuisAPIHostName": "Your LUIS App region here (i.e: westus.api.cognitive.microsoft.com)"
+```
+
+### Add Application Insights service to enable the bot monitoring
+Application Insights resource creation steps can be found [here](https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource).
+
+## To try this sample
+
+- Clone the repository
+
+    ```bash
+    git clone https://github.com/microsoft/botbuilder-samples.git
+    ```
+
+- In a terminal, navigate to `samples/javascript_nodejs/13.core-bot`
+
+    ```bash
+    cd samples/javascript_nodejs/13.core-bot
+    ```
+
+- Install modules
+
+    ```bash
+    npm install
+    ```
+
+- Setup LUIS
+
+    The prerequisites outlined above contain the steps necessary to provision a language understanding model on www.luis.ai.  Refer to _Create a LUIS Application to enable language understanding_ above for directions to setup and configure LUIS.
+
+- Run the sample
+
+    ```bash
+    npm start
+    ```
+
+## Testing the bot using Bot Framework Emulator
+
+[Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
+
+- Install the Bot Framework Emulator version 4.3.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+
+### Connect to the bot using Bot Framework Emulator
+
+- Launch Bot Framework Emulator
+- File -> Open Bot
+- Enter a Bot URL of `http://localhost:3978/api/messages`
+
+## Deploy the bot to Azure
+
+To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.
+
+## Further reading
+
+- [Bot Framework Documentation](https://docs.botframework.com)
+- [Bot Basics](https://docs.microsoft.com/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
+- [Dialogs](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-dialog?view=azure-bot-service-4.0)
+- [Gathering Input Using Prompts](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-prompts?view=azure-bot-service-4.0&tabs=csharp)
+- [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
+- [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
+- [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
+- [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
+- [Azure Portal](https://portal.azure.com)
+- [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)
+- [Channels and Bot Connector Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-concepts?view=azure-bot-service-4.0)
+- [Restify](https://www.npmjs.com/package/restify)
+- [dotenv](https://www.npmjs.com/package/dotenv)

--- a/samples/javascript_nodejs/21.corebot-app-insights/README.md
+++ b/samples/javascript_nodejs/21.corebot-app-insights/README.md
@@ -30,12 +30,13 @@ and [Application Insights](https://docs.microsoft.com/azure/azure-monitor/app/cl
 
 The LUIS model for this example can be found under `CognitiveModels/FlightBooking.json` and the LUIS language model setup, training, and application configuration steps can be found [here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-luis?view=azure-bot-service-4.0&tabs=cs).
 
-Once you created the LUIS model, update `appsettings.json` with your `LuisAppId`, `LuisAPIKey` and `LuisAPIHostName`.
+Once you created the LUIS model, update `.env` with your `LuisAppId`, `LuisAPIKey`, `LuisAPIHostName` and AppInsights's `InstrumentationKey` (more info on instrumentation key [here](https://docs.microsoft.com/en-us/azure/azure-monitor/app/create-new-resource#copy-the-instrumentation-key)).
 
 ```json
   "LuisAppId": "Your LUIS App Id",
   "LuisAPIKey": "Your LUIS Subscription key here",
   "LuisAPIHostName": "Your LUIS App region here (i.e: westus.api.cognitive.microsoft.com)"
+  "InstrumentationKey": "Your AppInsights instrumentation key here"
 ```
 
 ### Add Application Insights service to enable the bot monitoring

--- a/samples/javascript_nodejs/21.corebot-app-insights/README.md
+++ b/samples/javascript_nodejs/21.corebot-app-insights/README.md
@@ -50,10 +50,10 @@ Application Insights resource creation steps can be found [here](https://docs.mi
     git clone https://github.com/microsoft/botbuilder-samples.git
     ```
 
-- In a terminal, navigate to `samples/javascript_nodejs/13.core-bot`
+- In a terminal, navigate to `samples/javascript_nodejs/21.corebot-app-insights`
 
     ```bash
-    cd samples/javascript_nodejs/13.core-bot
+    cd samples/javascript_nodejs/21.corebot-app-insights
     ```
 
 - Install modules
@@ -64,7 +64,7 @@ Application Insights resource creation steps can be found [here](https://docs.mi
 
 - Setup LUIS
 
-    The prerequisites outlined above contain the steps necessary to provision a language understanding model on www.luis.ai.  Refer to _Create a LUIS Application to enable language understanding_ above for directions to setup and configure LUIS.
+    The prerequisites outlined above contain the steps necessary to provision a language understanding model on www.luis.ai. Refer to _Create a LUIS Application to enable language understanding_ above for directions to setup and configure LUIS.
 
 - Run the sample
 
@@ -100,6 +100,7 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](htt
 - [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
 - [Azure Portal](https://portal.azure.com)
 - [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)
+- [Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)
 - [Channels and Bot Connector Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-concepts?view=azure-bot-service-4.0)
 - [Restify](https://www.npmjs.com/package/restify)
 - [dotenv](https://www.npmjs.com/package/dotenv)

--- a/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogAndWelcomeBot.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogAndWelcomeBot.js
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { CardFactory } = require('botbuilder');
+const { DialogBot } = require('./dialogBot');
+const WelcomeCard = require('./resources/welcomeCard.json');
+
+class DialogAndWelcomeBot extends DialogBot {
+    /**
+     * 
+     * @param {ConversationState} conversationState 
+     * @param {UserState} userState 
+     * @param {Dialog} dialog 
+     */
+    constructor(conversationState, userState, dialog) {
+        super(conversationState, userState, dialog);
+
+        this.onMembersAdded(async (turnContext, next) => {
+            const membersAdded = turnContext.activity.membersAdded;
+
+            for (let pos = 0; pos < membersAdded.length; pos++) {                
+
+                if (membersAdded[pos].id != turnContext.activity.recipient.id) {
+                    const welcomeCard = CardFactory.adaptiveCard(WelcomeCard);
+                    await turnContext.sendActivity({ attachments: [welcomeCard] });
+                    await dialog.run(turnContext, conversationState.createProperty('DialogState'));
+                }
+            }
+
+            // Ensure next BotHandler is executed.
+            await next();
+        })
+    }
+}
+
+module.exports.DialogAndWelcomeBot = DialogAndWelcomeBot;

--- a/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogAndWelcomeBot.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogAndWelcomeBot.js
@@ -7,7 +7,6 @@ const WelcomeCard = require('./resources/welcomeCard.json');
 
 class DialogAndWelcomeBot extends DialogBot {
     /**
-     * 
      * @param {ConversationState} conversationState 
      * @param {UserState} userState 
      * @param {Dialog} dialog 
@@ -18,15 +17,14 @@ class DialogAndWelcomeBot extends DialogBot {
         this.onMembersAdded(async (turnContext, next) => {
             const membersAdded = turnContext.activity.membersAdded;
 
-            for (let pos = 0; pos < membersAdded.length; pos++) {                
-
+            for (let pos = 0; pos < membersAdded.length; pos++) {
                 if (membersAdded[pos].id != turnContext.activity.recipient.id) {
                     const welcomeCard = CardFactory.adaptiveCard(WelcomeCard);
+
                     await turnContext.sendActivity({ attachments: [welcomeCard] });
                     await dialog.run(turnContext, conversationState.createProperty('DialogState'));
                 }
             }
-
             // Ensure next BotHandler is executed.
             await next();
         })

--- a/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogAndWelcomeBot.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogAndWelcomeBot.js
@@ -7,9 +7,9 @@ const WelcomeCard = require('./resources/welcomeCard.json');
 
 class DialogAndWelcomeBot extends DialogBot {
     /**
-     * @param {ConversationState} conversationState 
-     * @param {UserState} userState 
-     * @param {Dialog} dialog 
+     * @param {ConversationState} conversationState
+     * @param {UserState} userState
+     * @param {Dialog} dialog
      */
     constructor(conversationState, userState, dialog) {
         super(conversationState, userState, dialog);
@@ -18,7 +18,7 @@ class DialogAndWelcomeBot extends DialogBot {
             const membersAdded = turnContext.activity.membersAdded;
 
             for (let pos = 0; pos < membersAdded.length; pos++) {
-                if (membersAdded[pos].id != turnContext.activity.recipient.id) {
+                if (membersAdded[pos].id !== turnContext.activity.recipient.id) {
                     const welcomeCard = CardFactory.adaptiveCard(WelcomeCard);
 
                     await turnContext.sendActivity({ attachments: [welcomeCard] });
@@ -27,7 +27,7 @@ class DialogAndWelcomeBot extends DialogBot {
             }
             // Ensure next BotHandler is executed.
             await next();
-        })
+        });
     }
 }
 

--- a/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogBot.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogBot.js
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { ActivityHandler } = require('botbuilder');
+
+class DialogBot extends ActivityHandler {
+    /**
+     * 
+     * @param {ConversationState} conversationState 
+     * @param {UserState} userState 
+     * @param {Dialog} dialog 
+     */
+    constructor(conversationState, userState, dialog) {
+        super();
+
+        if (!conversationState) { throw new Error("[DialogBot]: Missing conversationState parameter."); }
+        if (!userState) { throw new Error("[DialogBot]: Missing userState parameter."); }
+        if (!dialog) { throw new Error("[DialogBot]: Missing dialog parameter."); }
+
+        this.conversationState = conversationState;
+        this.userState = userState;
+        this.dialog = dialog;
+
+        this.onTurn(async (turnContext, next) => {
+            await this.conversationState.saveChanges(turnContext, false);
+            await this.userState.saveChanges(turnContext, false);
+
+            await next();
+        });
+
+        this.onMessage(async (turnContext, next) => {
+            console.log('Running dialog with Message Activity.');
+            let dialogState = this.conversationState.createProperty('');
+            
+            await this.dialog.run(turnContext, dialogState);
+
+            await next();
+        });
+    }
+}

--- a/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogBot.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogBot.js
@@ -5,16 +5,16 @@ const { ActivityHandler } = require('botbuilder');
 
 class DialogBot extends ActivityHandler {
     /**
-     * @param {ConversationState} conversationState 
-     * @param {UserState} userState 
-     * @param {Dialog} dialog 
+     * @param {ConversationState} conversationState
+     * @param {UserState} userState
+     * @param {Dialog} dialog
      */
     constructor(conversationState, userState, dialog) {
         super();
 
-        if (!conversationState) { throw new Error("[DialogBot]: Missing conversationState parameter."); }
-        if (!userState) { throw new Error("[DialogBot]: Missing userState parameter."); }
-        if (!dialog) { throw new Error("[DialogBot]: Missing dialog parameter."); }
+        if (!conversationState) { throw new Error('[DialogBot]: Missing conversationState parameter.'); }
+        if (!userState) { throw new Error('[DialogBot]: Missing userState parameter.'); }
+        if (!dialog) { throw new Error('[DialogBot]: Missing dialog parameter.'); }
 
         this.conversationState = conversationState;
         this.userState = userState;
@@ -30,8 +30,8 @@ class DialogBot extends ActivityHandler {
 
         this.onMessage(async (turnContext, next) => {
             console.log('Running dialog with Message Activity.');
-            let dialogState = this.conversationState.createProperty('DialogState');
-            
+            const dialogState = this.conversationState.createProperty('DialogState');
+
             await this.dialog.run(turnContext, dialogState);
 
             // Ensure next BotHandler is executed.

--- a/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogBot.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogBot.js
@@ -38,3 +38,5 @@ class DialogBot extends ActivityHandler {
         });
     }
 }
+
+module.exports.DialogBot = DialogBot;

--- a/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogBot.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogBot.js
@@ -5,7 +5,6 @@ const { ActivityHandler } = require('botbuilder');
 
 class DialogBot extends ActivityHandler {
     /**
-     * 
      * @param {ConversationState} conversationState 
      * @param {UserState} userState 
      * @param {Dialog} dialog 
@@ -25,6 +24,7 @@ class DialogBot extends ActivityHandler {
             await this.conversationState.saveChanges(turnContext, false);
             await this.userState.saveChanges(turnContext, false);
 
+            // Ensure next BotHandler is executed.
             await next();
         });
 
@@ -34,6 +34,7 @@ class DialogBot extends ActivityHandler {
             
             await this.dialog.run(turnContext, dialogState);
 
+            // Ensure next BotHandler is executed.
             await next();
         });
     }

--- a/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogBot.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogBot.js
@@ -37,6 +37,15 @@ class DialogBot extends ActivityHandler {
             // Ensure next BotHandler is executed.
             await next();
         });
+
+        this.onDialog(async (context, next) => {
+            // Save any state changes. The load happened during the execution of the Dialog.
+            await this.conversationState.saveChanges(context, false);
+            await this.userState.saveChanges(context, false);
+
+            // By calling next() you ensure that the next BotHandler is run.
+            await next();
+        });
     }
 }
 

--- a/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogBot.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/bots/dialogBot.js
@@ -30,7 +30,7 @@ class DialogBot extends ActivityHandler {
 
         this.onMessage(async (turnContext, next) => {
             console.log('Running dialog with Message Activity.');
-            let dialogState = this.conversationState.createProperty('');
+            let dialogState = this.conversationState.createProperty('DialogState');
             
             await this.dialog.run(turnContext, dialogState);
 

--- a/samples/javascript_nodejs/21.corebot-app-insights/bots/resources/welcomeCard.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/bots/resources/welcomeCard.json
@@ -20,7 +20,7 @@
       {
         "type": "TextBlock",
         "size": "default",
-        "isSubtle": "yes",
+        "isSubtle": "true",
         "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
         "wrap": true,
         "maxLines": 0

--- a/samples/javascript_nodejs/21.corebot-app-insights/bots/resources/welcomeCard.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/bots/resources/welcomeCard.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.0",
+    "body": [
+      {
+        "type": "Image",
+        "url": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU",
+        "size": "stretch"
+      },
+      {
+        "type": "TextBlock",
+        "spacing": "medium",
+        "size": "default",
+        "weight": "bolder",
+        "text": "Welcome to Bot Framework!",
+        "wrap": true,
+        "maxLines": 0
+      },
+      {
+        "type": "TextBlock",
+        "size": "default",
+        "isSubtle": "yes",
+        "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
+        "wrap": true,
+        "maxLines": 0
+      }
+    ],
+    "actions": [
+      {
+        "type": "Action.OpenUrl",
+        "title": "Get an overview",
+        "url": "https://docs.microsoft.com/en-us/azure/bot-service/?view=azure-bot-service-4.0"
+      },
+      {
+        "type": "Action.OpenUrl",
+        "title": "Ask a question",
+        "url": "https://stackoverflow.com/questions/tagged/botframework"
+      },
+      {
+        "type": "Action.OpenUrl",
+        "title": "Learn how to deploy",
+        "url": "https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-deploy-azure?view=azure-bot-service-4.0"
+      }
+    ]
+  }

--- a/samples/javascript_nodejs/21.corebot-app-insights/cognitiveModels/FlightBooking.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/cognitiveModels/FlightBooking.json
@@ -1,0 +1,339 @@
+{
+  "luis_schema_version": "3.2.0",
+  "versionId": "0.1",
+  "name": "FlightBooking",
+  "desc": "Luis Model for CoreBot",
+  "culture": "en-us",
+  "tokenizerVersion": "1.0.0",
+  "intents": [
+    {
+      "name": "BookFlight"
+    },
+    {
+      "name": "Cancel"
+    },
+    {
+      "name": "GetWeather"
+    },
+    {
+      "name": "None"
+    }
+  ],
+  "entities": [],
+  "composites": [
+    {
+      "name": "From",
+      "children": [
+        "Airport"
+      ],
+      "roles": []
+    },
+    {
+      "name": "To",
+      "children": [
+        "Airport"
+      ],
+      "roles": []
+    }
+  ],
+  "closedLists": [
+    {
+      "name": "Airport",
+      "subLists": [
+        {
+          "canonicalForm": "Paris",
+          "list": [
+            "paris",
+            "cdg"
+          ]
+        },
+        {
+          "canonicalForm": "London",
+          "list": [
+            "london",
+            "lhr"
+          ]
+        },
+        {
+          "canonicalForm": "Berlin",
+          "list": [
+            "berlin",
+            "txl"
+          ]
+        },
+        {
+          "canonicalForm": "New York",
+          "list": [
+            "new york",
+            "jfk"
+          ]
+        },
+        {
+          "canonicalForm": "Seattle",
+          "list": [
+            "seattle",
+            "sea"
+          ]
+        }
+      ],
+      "roles": []
+    }
+  ],
+  "patternAnyEntities": [],
+  "regex_entities": [],
+  "prebuiltEntities": [
+    {
+      "name": "datetimeV2",
+      "roles": []
+    }
+  ],
+  "model_features": [],
+  "regex_features": [],
+  "patterns": [],
+  "utterances": [
+    {
+      "text": "book a flight",
+      "intent": "BookFlight",
+      "entities": []
+    },
+    {
+      "text": "book a flight from new york",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 19,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "book a flight from seattle",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 19,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "book a hotel in new york",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "book a restaurant",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "book flight from london to paris on feb 14th",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 17,
+          "endPos": 22
+        },
+        {
+          "entity": "To",
+          "startPos": 27,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "book flight to berlin on feb 14th",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "To",
+          "startPos": 15,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "book me a flight from london to paris",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 22,
+          "endPos": 27
+        },
+        {
+          "entity": "To",
+          "startPos": 32,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "bye",
+      "intent": "Cancel",
+      "entities": []
+    },
+    {
+      "text": "cancel booking",
+      "intent": "Cancel",
+      "entities": []
+    },
+    {
+      "text": "exit",
+      "intent": "Cancel",
+      "entities": []
+    },
+    {
+      "text": "find an airport near me",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "flight to paris",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "To",
+          "startPos": 10,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "flight to paris from london on feb 14th",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "To",
+          "startPos": 10,
+          "endPos": 14
+        },
+        {
+          "entity": "From",
+          "startPos": 21,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "fly from berlin to paris on may 5th",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 9,
+          "endPos": 14
+        },
+        {
+          "entity": "To",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "go to paris",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "To",
+          "startPos": 6,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "going from paris to berlin",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 11,
+          "endPos": 15
+        },
+        {
+          "entity": "To",
+          "startPos": 20,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "i'd like to rent a car",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "ignore",
+      "intent": "Cancel",
+      "entities": []
+    },
+    {
+      "text": "travel from new york to paris",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "From",
+          "startPos": 12,
+          "endPos": 19
+        },
+        {
+          "entity": "To",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "travel to new york",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "To",
+          "startPos": 10,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "travel to paris",
+      "intent": "BookFlight",
+      "entities": [
+        {
+          "entity": "To",
+          "startPos": 10,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "what's the forecast for this friday?",
+      "intent": "GetWeather",
+      "entities": []
+    },
+    {
+      "text": "what's the weather like for tomorrow",
+      "intent": "GetWeather",
+      "entities": []
+    },
+    {
+      "text": "what's the weather like in new york",
+      "intent": "GetWeather",
+      "entities": []
+    },
+    {
+      "text": "what's the weather like?",
+      "intent": "GetWeather",
+      "entities": []
+    },
+    {
+      "text": "winter is coming",
+      "intent": "None",
+      "entities": []
+    }
+  ],
+  "settings": []
+}

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/new-rg-parameters.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,183 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location of the Resource Group."
+            }
+        },
+        "groupName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Resource Group."
+            }
+        },
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "newAppServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan. Defaults to \"westus\"."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        }
+    },
+    "variables": {
+        "appServicePlanName": "[parameters('newAppServicePlanName')]",
+        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+    },
+    "resources": [
+        {
+            "name": "[parameters('groupName')]",
+            "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2018-05-01",
+            "location": "[parameters('groupLocation')]",
+            "properties": {
+            }
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "storageDeployment",
+            "resourceGroup": "[parameters('groupName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "comments": "Create a new App Service Plan",
+                            "type": "Microsoft.Web/serverfarms",
+                            "name": "[variables('appServicePlanName')]",
+                            "apiVersion": "2018-02-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "properties": {
+                                "name": "[variables('appServicePlanName')]"
+                            }
+                        },
+                        {
+                            "comments": "Create a Web App using the new App Service Plan",
+                            "type": "Microsoft.Web/sites",
+                            "apiVersion": "2015-08-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "kind": "app",
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                            ],
+                            "name": "[variables('webAppName')]",
+                            "properties": {
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "siteConfig": {
+                                    "appSettings": [
+                                        {
+                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                            "value": "10.14.1"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppId",
+                                            "value": "[parameters('appId')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppPassword",
+                                            "value": "[parameters('appSecret')]"
+                                        }
+                                    ],
+                                    "cors": {
+                                        "allowedOrigins": [
+                                            "https://botservice.hosting.portal.azure.net",
+                                            "https://hosting.onecloud.azure-test.net/"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "apiVersion": "2017-12-01",
+                            "type": "Microsoft.BotService/botServices",
+                            "name": "[parameters('botId')]",
+                            "location": "global",
+                            "kind": "bot",
+                            "sku": {
+                                "name": "[parameters('botSku')]"
+                            },
+                            "properties": {
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
+                                "developerAppInsightsApplicationId": null,
+                                "developerAppInsightKey": null,
+                                "publishingCredentials": null,
+                                "storageResourceId": null
+                            },
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                            ]
+                        }
+                    ],
+                    "outputs": {}
+                }
+            }
+        }
+    ]
+}

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,154 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "defaultValue": "F0",
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The name of the new App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "appServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan."
+            }
+        },
+        "existingAppServicePlan": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        }
+    },
+    "variables": {
+        "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+        "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+        "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+        "resourcesLocation": "[parameters('appServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+    },
+    "resources": [
+        {
+            "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+            "type": "Microsoft.Web/serverfarms",
+            "condition": "[not(variables('useExistingAppServicePlan'))]",
+            "name": "[variables('servicePlanName')]",
+            "apiVersion": "2018-02-01",
+            "location": "[variables('resourcesLocation')]",
+            "sku": "[parameters('newAppServicePlanSku')]",
+            "properties": {
+                "name": "[variables('servicePlanName')]"
+            }
+        },
+        {
+            "comments": "Create a Web App using an App Service Plan",
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2015-08-01",
+            "location": "[variables('resourcesLocation')]",
+            "kind": "app",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+            ],
+            "name": "[variables('webAppName')]",
+            "properties": {
+                "name": "[variables('webAppName')]",
+                "serverFarmId": "[variables('servicePlanName')]",
+                "siteConfig": {
+                    "appSettings": [
+                        {
+                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                            "value": "10.14.1"
+                        },
+                        {
+                            "name": "MicrosoftAppId",
+                            "value": "[parameters('appId')]"
+                        },
+                        {
+                            "name": "MicrosoftAppPassword",
+                            "value": "[parameters('appSecret')]"
+                        }
+                    ],
+                    "cors": {
+                        "allowedOrigins": [
+                            "https://botservice.hosting.portal.azure.net",
+                            "https://hosting.onecloud.azure-test.net/"
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2017-12-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
+            "location": "global",
+            "kind": "bot",
+            "sku": {
+                "name": "[parameters('botSku')]"
+            },
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "developerAppInsightsApplicationId": null,
+                "developerAppInsightKey": null,
+                "publishingCredentials": null,
+                "storageResourceId": null
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        }
+    ]
+}

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/bookingDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/bookingDialog.js
@@ -13,17 +13,14 @@ const TEXT_PROMPT = 'textPrompt';
 const WATERFALL_DIALOG = 'waterfallDialog';
 
 class BookingDialog extends CancelAndHelpDialog {
-    constructor(telemetryClient) {
+    constructor() {
         super('bookingDialog');
 
         const textPrompt = new TextPrompt(TEXT_PROMPT);
-        textPrompt.telemetryClient = telemetryClient;
 
         const confirmPrompt = new ConfirmPrompt(CONFIRM_PROMPT);
-        confirmPrompt.telemetryClient = telemetryClient;
 
         const dateResolveDialog = new DateResolverDialog(DATE_RESOLVER_DIALOG);
-        dateResolveDialog.telemetryClient = telemetryClient;
 
         const waterFallDialog = new WaterfallDialog(WATERFALL_DIALOG, [
             this.destinationStep.bind(this),
@@ -32,8 +29,6 @@ class BookingDialog extends CancelAndHelpDialog {
             this.confirmStep.bind(this),
             this.finalStep.bind(this)
         ]);
-
-        waterFallDialog.telemetryClient = telemetryClient;
 
         this.addDialog(textPrompt)
             .addDialog(confirmPrompt)

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/bookingDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/bookingDialog.js
@@ -16,16 +16,29 @@ class BookingDialog extends CancelAndHelpDialog {
     constructor(telemetryClient) {
         super('bookingDialog');
 
-        this.addDialog((new TextPrompt(TEXT_PROMPT)).telemetryClient(telemetryClient))
-            .addDialog((new ConfirmPrompt(CONFIRM_PROMPT)).telemetryClient(telemetryClient))
-            .addDialog((new DateResolverDialog(DATE_RESOLVER_DIALOG)).telemetryClient(telemetryClient))
-            .addDialog((new WaterfallDialog(WATERFALL_DIALOG, [
-                this.destinationStep.bind(this),
-                this.originStep.bind(this),
-                this.travelDateStep.bind(this),
-                this.confirmStep.bind(this),
-                this.finalStep.bind(this)
-            ]).telemetryClient(telemetryClient)));
+        let textPrompt = new TextPrompt(TEXT_PROMPT);
+        textPrompt.telemetryClient = telemetryClient;
+
+        let confirmPrompt = new ConfirmPrompt(CONFIRM_PROMPT);
+        confirmPrompt.telemetryClient = telemetryClient;
+
+        let dateResolveDialog = new DateResolverDialog(DATE_RESOLVER_DIALOG);
+        dateResolveDialog.telemetryClient = telemetryClient;
+
+        let waterFallDialog = new WaterfallDialog(WATERFALL_DIALOG, [
+            this.destinationStep.bind(this),
+            this.originStep.bind(this),
+            this.travelDateStep.bind(this),
+            this.confirmStep.bind(this),
+            this.finalStep.bind(this)
+        ]);
+
+        waterFallDialog.telemetryClient = telemetryClient;
+
+        this.addDialog(textPrompt)
+            .addDialog(confirmPrompt)
+            .addDialog(dateResolveDialog)
+            .addDialog(waterFallDialog);
 
         this.initialDialogId = WATERFALL_DIALOG;
     }

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/bookingDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/bookingDialog.js
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { TimexProperty } = require('@microsoft/recognizers-text-data-types-timex-expression');
+const { InputHints, MessageFactory } = require('botbuilder');
+const { ConfirmPrompt, TextPrompt, WaterfallDialog } = require('botbuilder-dialogs');
+const { CancelAndHelpDialog } = require('./cancelAndHelpDialog');
+const { DateResolverDialog } = require('./dateResolverDialog');
+
+const CONFIRM_PROMPT = 'confirmPrompt';
+const DATE_RESOLVER_DIALOG = 'dateResolverDialog';
+const TEXT_PROMPT = 'textPrompt';
+const WATERFALL_DIALOG = 'waterfallDialog';
+
+class BookingDialog extends CancelAndHelpDialog {
+    constructor(telemetryClient) {
+        super('bookingDialog');
+
+        this.addDialog((new TextPrompt(TEXT_PROMPT)).telemetryClient(telemetryClient))
+            .addDialog((new ConfirmPrompt(CONFIRM_PROMPT)).telemetryClient(telemetryClient))
+            .addDialog((new DateResolverDialog(DATE_RESOLVER_DIALOG)).telemetryClient(telemetryClient))
+            .addDialog((new WaterfallDialog(WATERFALL_DIALOG, [
+                this.destinationStep.bind(this),
+                this.originStep.bind(this),
+                this.travelDateStep.bind(this),
+                this.confirmStep.bind(this),
+                this.finalStep.bind(this)
+            ]).telemetryClient(telemetryClient)));
+
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    /**
+     * If a destination city has not been provided, prompt for one.
+     */
+    async destinationStep(stepContext) {
+        const bookingDetails = stepContext.options;
+
+        if (!bookingDetails.destination) {
+            const messageText = 'To what city would you like to travel?';
+            const msg = MessageFactory.text(messageText, messageText, InputHints.ExpectingInput);
+            return await stepContext.prompt(TEXT_PROMPT, { prompt: msg });
+        }
+        return await stepContext.next(bookingDetails.destination);
+    }
+
+    /**
+     * If an origin city has not been provided, prompt for one.
+     */
+    async originStep(stepContext) {
+        const bookingDetails = stepContext.options;
+
+        // Capture the response to the previous step's prompt
+        bookingDetails.destination = stepContext.result;
+        if (!bookingDetails.origin) {
+            const messageText = 'From what city will you be travelling?';
+            const msg = MessageFactory.text(messageText, 'From what city will you be travelling?', InputHints.ExpectingInput);
+            return await stepContext.prompt(TEXT_PROMPT, { prompt: msg });
+        }
+        return await stepContext.next(bookingDetails.origin);
+    }
+
+    /**
+     * If a travel date has not been provided, prompt for one.
+     * This will use the DATE_RESOLVER_DIALOG.
+     */
+    async travelDateStep(stepContext) {
+        const bookingDetails = stepContext.options;
+
+        // Capture the results of the previous step
+        bookingDetails.origin = stepContext.result;
+        if (!bookingDetails.travelDate || this.isAmbiguous(bookingDetails.travelDate)) {
+            return await stepContext.beginDialog(DATE_RESOLVER_DIALOG, { date: bookingDetails.travelDate });
+        }
+        return await stepContext.next(bookingDetails.travelDate);
+    }
+
+    /**
+     * Confirm the information the user has provided.
+     */
+    async confirmStep(stepContext) {
+        const bookingDetails = stepContext.options;
+
+        // Capture the results of the previous step
+        bookingDetails.travelDate = stepContext.result;
+        const messageText = `Please confirm, I have you traveling to: ${ bookingDetails.destination } from: ${ bookingDetails.origin } on: ${ bookingDetails.travelDate }. Is this correct?`;
+        const msg = MessageFactory.text(messageText, messageText, InputHints.ExpectingInput);
+
+        // Offer a YES/NO prompt.
+        return await stepContext.prompt(CONFIRM_PROMPT, { prompt: msg });
+    }
+
+    /**
+     * Complete the interaction and end the dialog.
+     */
+    async finalStep(stepContext) {
+        if (stepContext.result === true) {
+            const bookingDetails = stepContext.options;
+            return await stepContext.endDialog(bookingDetails);
+        }
+        return await stepContext.endDialog();
+    }
+
+    isAmbiguous(timex) {
+        const timexPropery = new TimexProperty(timex);
+        return !timexPropery.types.has('definite');
+    }
+}
+
+module.exports.BookingDialog = BookingDialog;

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/bookingDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/bookingDialog.js
@@ -16,16 +16,16 @@ class BookingDialog extends CancelAndHelpDialog {
     constructor(telemetryClient) {
         super('bookingDialog');
 
-        let textPrompt = new TextPrompt(TEXT_PROMPT);
+        const textPrompt = new TextPrompt(TEXT_PROMPT);
         textPrompt.telemetryClient = telemetryClient;
 
-        let confirmPrompt = new ConfirmPrompt(CONFIRM_PROMPT);
+        const confirmPrompt = new ConfirmPrompt(CONFIRM_PROMPT);
         confirmPrompt.telemetryClient = telemetryClient;
 
-        let dateResolveDialog = new DateResolverDialog(DATE_RESOLVER_DIALOG);
+        const dateResolveDialog = new DateResolverDialog(DATE_RESOLVER_DIALOG);
         dateResolveDialog.telemetryClient = telemetryClient;
 
-        let waterFallDialog = new WaterfallDialog(WATERFALL_DIALOG, [
+        const waterFallDialog = new WaterfallDialog(WATERFALL_DIALOG, [
             this.destinationStep.bind(this),
             this.originStep.bind(this),
             this.travelDateStep.bind(this),

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/bookingDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/bookingDialog.js
@@ -13,27 +13,19 @@ const TEXT_PROMPT = 'textPrompt';
 const WATERFALL_DIALOG = 'waterfallDialog';
 
 class BookingDialog extends CancelAndHelpDialog {
-    constructor() {
-        super('bookingDialog');
+    constructor(id) {
+        super(id || 'bookingDialog');
 
-        const textPrompt = new TextPrompt(TEXT_PROMPT);
-
-        const confirmPrompt = new ConfirmPrompt(CONFIRM_PROMPT);
-
-        const dateResolveDialog = new DateResolverDialog(DATE_RESOLVER_DIALOG);
-
-        const waterFallDialog = new WaterfallDialog(WATERFALL_DIALOG, [
-            this.destinationStep.bind(this),
-            this.originStep.bind(this),
-            this.travelDateStep.bind(this),
-            this.confirmStep.bind(this),
-            this.finalStep.bind(this)
-        ]);
-
-        this.addDialog(textPrompt)
-            .addDialog(confirmPrompt)
-            .addDialog(dateResolveDialog)
-            .addDialog(waterFallDialog);
+        this.addDialog(new TextPrompt(TEXT_PROMPT))
+            .addDialog(new ConfirmPrompt(CONFIRM_PROMPT))
+            .addDialog(new DateResolverDialog(DATE_RESOLVER_DIALOG))
+            .addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+                this.destinationStep.bind(this),
+                this.originStep.bind(this),
+                this.travelDateStep.bind(this),
+                this.confirmStep.bind(this),
+                this.finalStep.bind(this)
+            ]));
 
         this.initialDialogId = WATERFALL_DIALOG;
     }

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/cancelAndHelpDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/cancelAndHelpDialog.js
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { InputHints } = require('botbuilder');
+const { ComponentDialog, DialogTurnStatus } = require('botbuilder-dialogs');
+
+
+/**
+ * This base class watches for common phrases like "help" and "cancel" and takes action on them
+ * BEFORE they reach the normal bot logic.
+ */
+class CancelAndHelpDialog extends ComponentDialog {
+    async onContinueDialog(innerDc) {
+        const result = await this.interrupt(innerDc);
+        if (result) {
+            return result;
+        }
+        return await super.onContinueDialog(innerDc);
+    }
+
+    async interrupt(innerDc) {
+        if (innerDc.context.activity.text) {
+            const text = innerDc.context.activity.text.toLowerCase();
+
+            switch (text) {
+            case 'help':
+            case '?':
+                const helpMessageText = 'Show help here';
+                await innerDc.context.sendActivity(helpMessageText, helpMessageText, InputHints.ExpectingInput);
+                return { status: DialogTurnStatus.waiting };
+            case 'cancel':
+            case 'quit':
+                const cancelMessageText = 'Cancelling...';
+                await innerDc.context.sendActivity(cancelMessageText, cancelMessageText, InputHints.IgnoringInput);
+                return await innerDc.cancelAllDialogs();
+            }
+        }
+    }
+}
+
+module.exports.CancelAndHelpDialog = CancelAndHelpDialog;

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/cancelAndHelpDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/cancelAndHelpDialog.js
@@ -23,17 +23,15 @@ class CancelAndHelpDialog extends ComponentDialog {
 
             switch (text) {
             case 'help':
-            case '?': {
+            case '?':
                 const helpMessageText = 'Show help here';
                 await innerDc.context.sendActivity(helpMessageText, helpMessageText, InputHints.ExpectingInput);
                 return { status: DialogTurnStatus.waiting };
-            }
             case 'cancel':
-            case 'quit': {
+            case 'quit':
                 const cancelMessageText = 'Cancelling...';
                 await innerDc.context.sendActivity(cancelMessageText, cancelMessageText, InputHints.IgnoringInput);
                 return await innerDc.cancelAllDialogs();
-            }
             }
         }
     }

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/cancelAndHelpDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/cancelAndHelpDialog.js
@@ -4,7 +4,6 @@
 const { InputHints } = require('botbuilder');
 const { ComponentDialog, DialogTurnStatus } = require('botbuilder-dialogs');
 
-
 /**
  * This base class watches for common phrases like "help" and "cancel" and takes action on them
  * BEFORE they reach the normal bot logic.
@@ -24,15 +23,17 @@ class CancelAndHelpDialog extends ComponentDialog {
 
             switch (text) {
             case 'help':
-            case '?':
+            case '?': {
                 const helpMessageText = 'Show help here';
                 await innerDc.context.sendActivity(helpMessageText, helpMessageText, InputHints.ExpectingInput);
                 return { status: DialogTurnStatus.waiting };
+            }
             case 'cancel':
-            case 'quit':
+            case 'quit': {
                 const cancelMessageText = 'Cancelling...';
                 await innerDc.context.sendActivity(cancelMessageText, cancelMessageText, InputHints.IgnoringInput);
                 return await innerDc.cancelAllDialogs();
+            }
             }
         }
     }

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/dateResolverDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/dateResolverDialog.js
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { InputHints, MessageFactory } = require('botbuilder');
+const { DateTimePrompt, WaterfallDialog } = require('botbuilder-dialogs');
+const { CancelAndHelpDialog } = require('./cancelAndHelpDialog');
+const { TimexProperty } = require('@microsoft/recognizers-text-data-types-timex-expression');
+
+const DATETIME_PROMPT = 'datetimePrompt';
+const WATERFALL_DIALOG = 'waterfallDialog';
+
+class DateResolverDialog extends CancelAndHelpDialog {
+    constructor(id) {
+        super(id || 'dateResolverDialog');
+        this.addDialog(new DateTimePrompt(DATETIME_PROMPT, this.dateTimePromptValidator.bind(this)))
+            .addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+                this.initialStep.bind(this),
+                this.finalStep.bind(this)
+            ]));
+
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    async initialStep(stepContext) {
+        const timex = stepContext.options.date;
+
+        const promptMessageText = 'On what date would you like to travel?';
+        const promptMessage = MessageFactory.text(promptMessageText, promptMessageText, InputHints.ExpectingInput);
+
+        const repromptMessageText = "I'm sorry, for best results, please enter your travel date including the month, day and year.";
+        const repromptMessage = MessageFactory.text(repromptMessageText, repromptMessageText, InputHints.ExpectingInput);
+
+        if (!timex) {
+            // We were not given any date at all so prompt the user.
+            return await stepContext.prompt(DATETIME_PROMPT,
+                {
+                    prompt: promptMessage,
+                    retryPrompt: repromptMessage
+                });
+        }
+        // We have a Date we just need to check it is unambiguous.
+        const timexProperty = new TimexProperty(timex);
+        if (!timexProperty.types.has('definite')) {
+            // This is essentially a "reprompt" of the data we were given up front.
+            return await stepContext.prompt(DATETIME_PROMPT, { prompt: repromptMessage });
+        }
+        return await stepContext.next([{ timex: timex }]);
+    }
+
+    async finalStep(stepContext) {
+        const timex = stepContext.result[0].timex;
+        return await stepContext.endDialog(timex);
+    }
+
+    async dateTimePromptValidator(promptContext) {
+        if (promptContext.recognized.succeeded) {
+            // This value will be a TIMEX. And we are only interested in a Date so grab the first result and drop the Time part.
+            // TIMEX is a format that represents DateTime expressions that include some ambiguity. e.g. missing a Year.
+            const timex = promptContext.recognized.value[0].timex.split('T')[0];
+
+            // If this is a definite Date including year, month and day we are good otherwise reprompt.
+            // A better solution might be to let the user know what part is actually missing.
+            return new TimexProperty(timex).types.has('definite');
+        }
+        return false;
+    }
+}
+
+module.exports.DateResolverDialog = DateResolverDialog;

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/flightBookingRecognizer.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/flightBookingRecognizer.js
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { LuisRecognizer } = require('botbuilder-ai');
+
+class FlightBookingRecognizer {
+    constructor(config) {
+        const luisIsConfigured = config && config.applicationId && config.endpointKey && config.endpoint;
+        if (luisIsConfigured) {
+            this.recognizer = new LuisRecognizer(config, {}, true);
+        }
+    }
+
+    get isConfigured() {
+        return (this.recognizer !== undefined);
+    }
+
+    /**
+     * Returns an object with preformatted LUIS results for the bot's dialogs to consume.
+     * @param {TurnContext} context
+     */
+    async executeLuisQuery(context) {
+        return await this.recognizer.recognize(context);
+    }
+
+    getFromEntities(result) {
+        let fromValue, fromAirportValue;
+        if (result.entities.$instance.From) {
+            fromValue = result.entities.$instance.From[0].text;
+        }
+        if (fromValue && result.entities.From[0].Airport) {
+            fromAirportValue = result.entities.From[0].Airport[0][0];
+        }
+
+        return { from: fromValue, airport: fromAirportValue };
+    }
+
+    getToEntities(result) {
+        let toValue, toAirportValue;
+        if (result.entities.$instance.To) {
+            toValue = result.entities.$instance.To[0].text;
+        }
+        if (toValue && result.entities.To[0].Airport) {
+            toAirportValue = result.entities.To[0].Airport[0][0];
+        }
+
+        return { to: toValue, airport: toAirportValue };
+    }
+
+    /**
+     * This value will be a TIMEX. And we are only interested in a Date so grab the first result and drop the Time part.
+     * TIMEX is a format that represents DateTime expressions that include some ambiguity. e.g. missing a Year.
+     */
+    getTravelDate(result) {
+        const datetimeEntity = result.entities['datetime'];
+        if (!datetimeEntity || !datetimeEntity[0]) return undefined;
+
+        const timex = datetimeEntity[0]['timex'];
+        if (!timex || !timex[0]) return undefined;
+
+        const datetime = timex[0].split('T')[0];
+        return datetime;
+    }
+}
+
+module.exports.FlightBookingRecognizer = FlightBookingRecognizer;

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/flightBookingRecognizer.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/flightBookingRecognizer.js
@@ -52,10 +52,10 @@ class FlightBookingRecognizer {
      * TIMEX is a format that represents DateTime expressions that include some ambiguity. e.g. missing a Year.
      */
     getTravelDate(result) {
-        const datetimeEntity = result.entities['datetime'];
+        const datetimeEntity = result.entities.datetime;
         if (!datetimeEntity || !datetimeEntity[0]) return undefined;
 
-        const timex = datetimeEntity[0]['timex'];
+        const timex = datetimeEntity[0].timex;
         if (!timex || !timex[0]) return undefined;
 
         const datetime = timex[0].split('T')[0];

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
@@ -23,6 +23,9 @@ class MainDialog extends ComponentDialog {
         this.luisRecognizer = luisRecognizer;
         this.telemetryClient = telemetryClient;
 
+        let textPrompt = new TextPrompt('TextPrompt');
+        textPrompt.telemetryClient = this.telemetryClient;
+
         let waterfallDialog = new WaterfallDialog(MAIN_WATERFALL_DIALOG, [
             this.introStep.bind(this),
             this.actStep.bind(this),
@@ -33,7 +36,7 @@ class MainDialog extends ComponentDialog {
 
         // Define the main dialog and its related components.
         // This is a sample "book a flight" dialog.
-        this.addDialog((new TextPrompt('TextPrompt')).telemetryClient = this.telemetryClient)
+        this.addDialog(textPrompt)
             .addDialog(new BookingDialog(telemetryClient))
             .addDialog(waterfallDialog);
 

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { ComponentDialog } = require('botbuilder-dialogs');
+
+class MainDialog extends ComponentDialog {
+    constructor() {
+        super('MainDialog');
+    }
+}
+
+module.exports.MainDialog = MainDialog;

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
@@ -12,29 +12,23 @@ class MainDialog extends ComponentDialog {
     /**
      * @param {*} luisRecognizer
      * @param {*} bookingDialog
-     * @param {*} telemetryClient
      */
-    constructor(luisRecognizer, bookingDialog, telemetryClient) {
+    constructor(luisRecognizer, bookingDialog) {
         super('MainDialog');
 
         if (!luisRecognizer) { throw new Error('[MainDialog]: Missing parameter \'luisRecognizer\' is required.'); }
         if (!bookingDialog) { throw new Error('[MainDialog]: Missing parameter \'bookingDialog\' is required.'); }
-        if (!telemetryClient) { throw new Error('[MainDialog]: Missing parameter \'telemetryClient\' is required.'); }
 
         this.luisRecognizer = luisRecognizer;
         this.bookingDialog = bookingDialog;
-        this.telemetryClient = telemetryClient;
 
         const textPrompt = new TextPrompt('TextPrompt');
-        textPrompt.telemetryClient = this.telemetryClient;
 
         const waterfallDialog = new WaterfallDialog(MAIN_WATERFALL_DIALOG, [
             this.introStep.bind(this),
             this.actStep.bind(this),
             this.finalStep.bind(this)
         ]);
-
-        waterfallDialog.telemetryClient = this.telemetryClient;
 
         // Define the main dialog and its related components.
         // This is a sample "book a flight" dialog.

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
@@ -126,7 +126,7 @@ class MainDialog extends ComponentDialog {
 
     /**
      * Shows a warning if the requested From or To cities are recognized as entities but they are not in the Airport entity list.
-     * In some cases LUIS will recognize the From and To composite entities as a valid cities but the From and To Airport values
+     * In some cases LUIS will recognize the From and To composite entities as valid cities but the From and To Airport values
      * will be empty if those entity values can't be mapped to a canonical item in the Airport.
      */
     async showWarningForUnsupportedCities(context, fromEntities, toEntities) {

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
@@ -3,7 +3,7 @@
 
 const { ComponentDialog, DialogSet, DialogTurnStatus, TextPrompt, WaterfallDialog } = require('botbuilder-dialogs');
 const { LuisRecognizer } = require('botbuilder-ai');
-const { BookingDialog } = require('../dialogs/bookingDialog')
+const { BookingDialog } = require('../dialogs/bookingDialog');
 const { TimexProperty } = require('@microsoft/recognizers-text-data-types-timex-expression');
 const { MessageFactory, InputHints } = require('botbuilder');
 
@@ -11,8 +11,8 @@ const MAIN_WATERFALL_DIALOG = 'mainWaterfallDialog';
 
 class MainDialog extends ComponentDialog {
     /**
-     * @param {*} luisRecognizer 
-     * @param {*} telemetryClient 
+     * @param {*} luisRecognizer
+     * @param {*} telemetryClient
      */
     constructor(luisRecognizer, telemetryClient) {
         super('MainDialog');
@@ -23,10 +23,10 @@ class MainDialog extends ComponentDialog {
         this.luisRecognizer = luisRecognizer;
         this.telemetryClient = telemetryClient;
 
-        let textPrompt = new TextPrompt('TextPrompt');
+        const textPrompt = new TextPrompt('TextPrompt');
         textPrompt.telemetryClient = this.telemetryClient;
 
-        let waterfallDialog = new WaterfallDialog(MAIN_WATERFALL_DIALOG, [
+        const waterfallDialog = new WaterfallDialog(MAIN_WATERFALL_DIALOG, [
             this.introStep.bind(this),
             this.actStep.bind(this),
             this.finalStep.bind(this)
@@ -92,7 +92,7 @@ class MainDialog extends ComponentDialog {
         // Call LUIS and gather any potential booking details. (Note the TurnContext has the response to the prompt)
         const luisResult = await this.luisRecognizer.executeLuisQuery(stepContext.context);
         switch (LuisRecognizer.topIntent(luisResult)) {
-        case 'BookFlight':
+        case 'BookFlight': {
             // Extract the values for the composite entities from the LUIS result.
             const fromEntities = this.luisRecognizer.getFromEntities(luisResult);
             const toEntities = this.luisRecognizer.getToEntities(luisResult);
@@ -108,17 +108,18 @@ class MainDialog extends ComponentDialog {
 
             // Run the BookingDialog passing in whatever details we have from the LUIS call, it will fill out the remainder.
             return await stepContext.beginDialog('bookingDialog', bookingDetails);
-
-        case 'GetWeather':
+        }
+        case 'GetWeather': {
             // We haven't implemented the GetWeatherDialog so we just display a TODO message.
             const getWeatherMessageText = 'TODO: get weather flow here';
             await stepContext.context.sendActivity(getWeatherMessageText, getWeatherMessageText, InputHints.IgnoringInput);
             break;
-
-        default:
+        }
+        default: {
             // Catch all for unhandled intents
             const didntUnderstandMessageText = `Sorry, I didn't get that. Please try asking in a different way (intent was ${ LuisRecognizer.topIntent(luisResult) })`;
             await stepContext.context.sendActivity(didntUnderstandMessageText, didntUnderstandMessageText, InputHints.IgnoringInput);
+        }
         }
 
         return await stepContext.next();
@@ -167,7 +168,6 @@ class MainDialog extends ComponentDialog {
         // Restart the main dialog with a different message the second time around
         return await stepContext.replaceDialog(this.initialDialogId, { restartMsg: 'What else can I do for you?' });
     }
-
 }
 
 module.exports.MainDialog = MainDialog;

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
@@ -1,12 +1,170 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const { ComponentDialog } = require('botbuilder-dialogs');
+const { ComponentDialog, DialogSet, DialogTurnStatus, TextPrompt, WaterfallDialog } = require('botbuilder-dialogs');
+const { LuisRecognizer } = require('botbuilder-ai');
+const { BookingDialog } = require('../dialogs/bookingDialog')
+const { TimexProperty } = require('@microsoft/recognizers-text-data-types-timex-expression');
+const { MessageFactory, InputHints } = require('botbuilder');
+
+const MAIN_WATERFALL_DIALOG = 'mainWaterfallDialog';
 
 class MainDialog extends ComponentDialog {
-    constructor() {
+    /**
+     * @param {*} luisRecognizer 
+     * @param {*} telemetryClient 
+     */
+    constructor(luisRecognizer, telemetryClient) {
         super('MainDialog');
+
+        if (!luisRecognizer) { throw new Error('[MainDialog]: Missing parameter \'luisRecognizer\' is required.'); }
+        if (!telemetryClient) { throw new Error('[MainDialog]: Missing parameter \'telemetryClient\' is required.'); }
+
+        this.luisRecognizer = luisRecognizer;
+        this.telemetryClient = telemetryClient;
+
+        let waterfallDialog = new WaterfallDialog(MAIN_WATERFALL_DIALOG, [
+            this.introStep.bind(this),
+            this.actStep.bind(this),
+            this.finalStep.bind(this)
+        ]);
+
+        waterfallDialog.telemetryClient = this.telemetryClient;
+
+        // Define the main dialog and its related components.
+        // This is a sample "book a flight" dialog.
+        this.addDialog((new TextPrompt('TextPrompt')).telemetryClient = this.telemetryClient)
+            .addDialog(new BookingDialog(telemetryClient))
+            .addDialog(waterfallDialog);
+
+        this.initialDialogId = MAIN_WATERFALL_DIALOG;
     }
+
+    /**
+     * The run method handles the incoming activity (in the form of a TurnContext) and passes it through the dialog system.
+     * If no dialog is active, it will start the default dialog.
+     * @param {*} turnContext
+     * @param {*} accessor
+     */
+    async run(turnContext, accessor) {
+        const dialogSet = new DialogSet(accessor);
+        dialogSet.add(this);
+
+        const dialogContext = await dialogSet.createContext(turnContext);
+        const results = await dialogContext.continueDialog();
+        if (results.status === DialogTurnStatus.empty) {
+            await dialogContext.beginDialog(this.id);
+        }
+    }
+
+    /**
+     * First step in the waterfall dialog. Prompts the user for a command.
+     * Currently, this expects a booking request, like "book me a flight from Paris to Berlin on march 22"
+     * Note that the sample LUIS model will only recognize Paris, Berlin, New York and London as airport cities.
+     */
+    async introStep(stepContext) {
+        if (!this.luisRecognizer.isConfigured) {
+            const messageText = 'NOTE: LUIS is not configured. To enable all capabilities, add `LuisAppId`, `LuisAPIKey` and `LuisAPIHostName` to the .env file.';
+            await stepContext.context.sendActivity(messageText, null, InputHints.IgnoringInput);
+            return await stepContext.next();
+        }
+
+        const messageText = stepContext.options.restartMsg ? stepContext.options.restartMsg : 'What can I help you with today?\nSay something like "Book a flight from Paris to Berlin on March 22, 2020"';
+        const promptMessage = MessageFactory.text(messageText, messageText, InputHints.ExpectingInput);
+        return await stepContext.prompt('TextPrompt', { prompt: promptMessage });
+    }
+
+    /**
+     * Second step in the waterfall.  This will use LUIS to attempt to extract the origin, destination and travel dates.
+     * Then, it hands off to the bookingDialog child dialog to collect any remaining details.
+     */
+    async actStep(stepContext) {
+        const bookingDetails = {};
+
+        if (!this.luisRecognizer.isConfigured) {
+            // LUIS is not configured, we just run the BookingDialog path.
+            return await stepContext.beginDialog('bookingDialog', bookingDetails);
+        }
+
+        // Call LUIS and gather any potential booking details. (Note the TurnContext has the response to the prompt)
+        const luisResult = await this.luisRecognizer.executeLuisQuery(stepContext.context);
+        switch (LuisRecognizer.topIntent(luisResult)) {
+        case 'BookFlight':
+            // Extract the values for the composite entities from the LUIS result.
+            const fromEntities = this.luisRecognizer.getFromEntities(luisResult);
+            const toEntities = this.luisRecognizer.getToEntities(luisResult);
+
+            // Show a warning for Origin and Destination if we can't resolve them.
+            await this.showWarningForUnsupportedCities(stepContext.context, fromEntities, toEntities);
+
+            // Initialize BookingDetails with any entities we may have found in the response.
+            bookingDetails.destination = toEntities.airport;
+            bookingDetails.origin = fromEntities.airport;
+            bookingDetails.travelDate = this.luisRecognizer.getTravelDate(luisResult);
+            console.log('LUIS extracted these booking details:', JSON.stringify(bookingDetails));
+
+            // Run the BookingDialog passing in whatever details we have from the LUIS call, it will fill out the remainder.
+            return await stepContext.beginDialog('bookingDialog', bookingDetails);
+
+        case 'GetWeather':
+            // We haven't implemented the GetWeatherDialog so we just display a TODO message.
+            const getWeatherMessageText = 'TODO: get weather flow here';
+            await stepContext.context.sendActivity(getWeatherMessageText, getWeatherMessageText, InputHints.IgnoringInput);
+            break;
+
+        default:
+            // Catch all for unhandled intents
+            const didntUnderstandMessageText = `Sorry, I didn't get that. Please try asking in a different way (intent was ${ LuisRecognizer.topIntent(luisResult) })`;
+            await stepContext.context.sendActivity(didntUnderstandMessageText, didntUnderstandMessageText, InputHints.IgnoringInput);
+        }
+
+        return await stepContext.next();
+    }
+
+    /**
+     * Shows a warning if the requested From or To cities are recognized as entities but they are not in the Airport entity list.
+     * In some cases LUIS will recognize the From and To composite entities as a valid cities but the From and To Airport values
+     * will be empty if those entity values can't be mapped to a canonical item in the Airport.
+     */
+    async showWarningForUnsupportedCities(context, fromEntities, toEntities) {
+        const unsupportedCities = [];
+        if (fromEntities.from && !fromEntities.airport) {
+            unsupportedCities.push(fromEntities.from);
+        }
+
+        if (toEntities.to && !toEntities.airport) {
+            unsupportedCities.push(toEntities.to);
+        }
+
+        if (unsupportedCities.length) {
+            const messageText = `Sorry but the following airports are not supported: ${ unsupportedCities.join(', ') }`;
+            await context.sendActivity(messageText, messageText, InputHints.IgnoringInput);
+        }
+    }
+
+    /**
+     * This is the final step in the main waterfall dialog.
+     * It wraps up the sample "book a flight" interaction with a simple confirmation.
+     */
+    async finalStep(stepContext) {
+        // If the child dialog ("bookingDialog") was cancelled or the user failed to confirm, the Result here will be null.
+        if (stepContext.result) {
+            const result = stepContext.result;
+            // Now we have all the booking details.
+
+            // This is where calls to the booking AOU service or database would go.
+
+            // If the call to the booking service was successful tell the user.
+            const timeProperty = new TimexProperty(result.travelDate);
+            const travelDateMsg = timeProperty.toNaturalLanguage(new Date(Date.now()));
+            const msg = `I have you booked to ${ result.destination } from ${ result.origin } on ${ travelDateMsg }.`;
+            await stepContext.context.sendActivity(msg, msg, InputHints.IgnoringInput);
+        }
+
+        // Restart the main dialog with a different message the second time around
+        return await stepContext.replaceDialog(this.initialDialogId, { restartMsg: 'What else can I do for you?' });
+    }
+
 }
 
 module.exports.MainDialog = MainDialog;

--- a/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/dialogs/mainDialog.js
@@ -3,7 +3,6 @@
 
 const { ComponentDialog, DialogSet, DialogTurnStatus, TextPrompt, WaterfallDialog } = require('botbuilder-dialogs');
 const { LuisRecognizer } = require('botbuilder-ai');
-const { BookingDialog } = require('../dialogs/bookingDialog');
 const { TimexProperty } = require('@microsoft/recognizers-text-data-types-timex-expression');
 const { MessageFactory, InputHints } = require('botbuilder');
 
@@ -12,15 +11,18 @@ const MAIN_WATERFALL_DIALOG = 'mainWaterfallDialog';
 class MainDialog extends ComponentDialog {
     /**
      * @param {*} luisRecognizer
+     * @param {*} bookingDialog
      * @param {*} telemetryClient
      */
-    constructor(luisRecognizer, telemetryClient) {
+    constructor(luisRecognizer, bookingDialog, telemetryClient) {
         super('MainDialog');
 
         if (!luisRecognizer) { throw new Error('[MainDialog]: Missing parameter \'luisRecognizer\' is required.'); }
+        if (!bookingDialog) { throw new Error('[MainDialog]: Missing parameter \'bookingDialog\' is required.'); }
         if (!telemetryClient) { throw new Error('[MainDialog]: Missing parameter \'telemetryClient\' is required.'); }
 
         this.luisRecognizer = luisRecognizer;
+        this.bookingDialog = bookingDialog;
         this.telemetryClient = telemetryClient;
 
         const textPrompt = new TextPrompt('TextPrompt');
@@ -37,7 +39,7 @@ class MainDialog extends ComponentDialog {
         // Define the main dialog and its related components.
         // This is a sample "book a flight" dialog.
         this.addDialog(textPrompt)
-            .addDialog(new BookingDialog(telemetryClient))
+            .addDialog(bookingDialog)
             .addDialog(waterfallDialog);
 
         this.initialDialogId = MAIN_WATERFALL_DIALOG;

--- a/samples/javascript_nodejs/21.corebot-app-insights/index.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/index.js
@@ -16,6 +16,7 @@ const { FlightBookingRecognizer } = require('./dialogs/flightBookingRecognizer')
 // This bot's main dialog.
 const { DialogAndWelcomeBot } = require('./bots/dialogAndWelcomeBot');
 const { MainDialog } = require('./dialogs/mainDialog');
+const { BookingDialog } = require('./dialogs/bookingDialog');
 
 // Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
 const ENV_FILE = path.join(__dirname, '.env');
@@ -60,7 +61,8 @@ const luisRecognizer = new FlightBookingRecognizer(luisConfig);
 const telemetryClient = getTelemetryClient(process.env.InstrumentationKey);
 
 // Create the main dialog.
-const dialog = new MainDialog(luisRecognizer, telemetryClient);
+const bookingDialog = new BookingDialog(telemetryClient);
+const dialog = new MainDialog(luisRecognizer, bookingDialog, telemetryClient);
 const bot = new DialogAndWelcomeBot(conversationState, userState, dialog);
 
 // Create HTTP server

--- a/samples/javascript_nodejs/21.corebot-app-insights/index.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/index.js
@@ -70,7 +70,7 @@ const server = restify.createServer();
 
 // Enable the Application Insights middleware, which helps correlate all activity
 // based on the incoming request.
-// server.use(restify.plugins.bodyParser());
+server.use(restify.plugins.bodyParser());
 server.use(ApplicationInsightsWebserverMiddleware);
 
 server.listen(process.env.port || process.env.PORT || 3978, function() {

--- a/samples/javascript_nodejs/21.corebot-app-insights/index.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/index.js
@@ -1,5 +1,90 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// index.js is used to setup and configure your bot
+
+// Import required packages
+const path = require('path');
+const restify = require('restify');
+
+const { ApplicationInsightsTelemetryClient, ApplicationInsightsWebserverMiddleware } = require ('botbuilder-applicationinsights');
+
+// Import required bot services. See https://aka.ms/bot-services to learn more about the different parts of a bot.
+const { BotFrameworkAdapter, ConversationState, InputHints, MemoryStorage, UserState } = require('botbuilder');
+const { FlightBookingRecognizer } = require('./dialogs/flightBookingRecognizer');
+
+// This bot's main dialog.
+const { DialogAndWelcomeBot } = require('./bots/dialogAndWelcomeBot');
+const { MainDialog } = require('./dialogs/mainDialog');
+
+// the bot's booking dialog
+const { BookingDialog } = require('./dialogs/bookingDialog');
+const BOOKING_DIALOG = 'bookingDialog';
+
+// Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
 const ENV_FILE = path.join(__dirname, '.env');
 require('dotenv').config({ path: ENV_FILE });
+
+// Create adapter.
+// See https://aka.ms/about-bot-adapter to learn more about adapters.
+const adapter = new BotFrameworkAdapter({
+    appId: process.env.MicrosoftAppId,
+    appPassword: process.env.MicrosoftAppPassword
+});
+
+// Catch-all for errors.
+adapter.onTurnError = async (context, error) => {
+    // This check writes out errors to console log
+    // NOTE: In production environment, you should consider logging this to Azure
+    //       application insights.
+    console.error(`\n [onTurnError]: ${ error }`);
+    // Send a message to the user
+    const onTurnErrorMessage = `Sorry, it looks like something went wrong!`;
+    await context.sendActivity(onTurnErrorMessage, onTurnErrorMessage, InputHints.ExpectingInput);
+    // Clear out state
+    await conversationState.delete(context);
+};
+
+// Define a state store for your bot. See https://aka.ms/about-bot-state to learn more about using MemoryStorage.
+// A bot requires a state store to persist the dialog and user state between messages.
+
+// For local development, in-memory storage is used.
+// CAUTION: The Memory Storage used here is for local bot debugging only. When the bot
+// is restarted, anything stored in memory will be gone.
+const memoryStorage = new MemoryStorage();
+const conversationState = new ConversationState(memoryStorage);
+const userState = new UserState(memoryStorage);
+
+// If configured, pass in the FlightBookingRecognizer.  (Defining it externally allows it to be mocked for tests)
+const { LuisAppId, LuisAPIKey, LuisAPIHostName } = process.env;
+const luisConfig = { applicationId: LuisAppId, endpointKey: LuisAPIKey, endpoint: `https://${ LuisAPIHostName }` };
+
+const luisRecognizer = new FlightBookingRecognizer(luisConfig);
+
+// Create the main dialog.
+//TO-DO
+const bookingDialog = new BookingDialog(BOOKING_DIALOG);
+const dialog = new MainDialog(luisRecognizer, bookingDialog);
+const bot = new DialogAndWelcomeBot(conversationState, userState, dialog);
+
+// Create HTTP server
+const server = restify.createServer();
+
+// Enable the Application Insights middleware, which helps correlate all activity
+// based on the incoming request.
+server.use(restify.plugins.bodyParser());
+server.use(ApplicationInsightsWebserverMiddleware)
+
+server.listen(process.env.port || process.env.PORT || 3978, function() {
+    console.log(`\n${ server.name } listening to ${ server.url }`);
+    console.log(`\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator`);
+});
+
+// Listen for incoming activities and route them to your bot main dialog.
+server.post('/api/messages', (req, res) => {
+    // Route received a request to adapter for processing
+    adapter.processActivity(req, res, async (turnContext) => {
+        // route to bot activity handler.
+        await bot.run(turnContext);
+    });
+});

--- a/samples/javascript_nodejs/21.corebot-app-insights/index.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/index.js
@@ -58,11 +58,11 @@ const luisConfig = { applicationId: LuisAppId, endpointKey: LuisAPIKey, endpoint
 
 const luisRecognizer = new FlightBookingRecognizer(luisConfig);
 
-const telemetryClient = getTelemetryClient(process.env.InstrumentationKey);
-
 // Create the main dialog.
-const bookingDialog = new BookingDialog(telemetryClient);
-const dialog = new MainDialog(luisRecognizer, bookingDialog, telemetryClient);
+const bookingDialog = new BookingDialog();
+const dialog = new MainDialog(luisRecognizer, bookingDialog);
+dialog.telemetryClient = getTelemetryClient(process.env.InstrumentationKey);
+
 const bot = new DialogAndWelcomeBot(conversationState, userState, dialog);
 
 // Create HTTP server

--- a/samples/javascript_nodejs/21.corebot-app-insights/index.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/index.js
@@ -7,7 +7,7 @@
 const path = require('path');
 const restify = require('restify');
 
-const { ApplicationInsightsTelemetryClient, ApplicationInsightsWebserverMiddleware } = require ('botbuilder-applicationinsights');
+const { ApplicationInsightsTelemetryClient, ApplicationInsightsWebserverMiddleware } = require('botbuilder-applicationinsights');
 
 // Import required bot services. See https://aka.ms/bot-services to learn more about the different parts of a bot.
 const { BotFrameworkAdapter, ConversationState, InputHints, MemoryStorage, NullTelemetryClient, UserState } = require('botbuilder');
@@ -16,9 +16,6 @@ const { FlightBookingRecognizer } = require('./dialogs/flightBookingRecognizer')
 // This bot's main dialog.
 const { DialogAndWelcomeBot } = require('./bots/dialogAndWelcomeBot');
 const { MainDialog } = require('./dialogs/mainDialog');
-
-// the bot's booking dialog
-const { BookingDialog } = require('./dialogs/bookingDialog');
 
 // Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
 const ENV_FILE = path.join(__dirname, '.env');
@@ -38,7 +35,7 @@ adapter.onTurnError = async (context, error) => {
     //       application insights.
     console.error(`\n [onTurnError]: ${ error }`);
     // Send a message to the user
-    const onTurnErrorMessage = `Sorry, it looks like something went wrong!`;
+    const onTurnErrorMessage = 'Sorry, it looks like something went wrong!';
     await context.sendActivity(onTurnErrorMessage, onTurnErrorMessage, InputHints.ExpectingInput);
     // Clear out state
     await conversationState.delete(context);
@@ -76,7 +73,7 @@ server.use(ApplicationInsightsWebserverMiddleware);
 
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }`);
-    console.log(`\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator`);
+    console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
 });
 
 // Listen for incoming activities and route them to your bot main dialog.

--- a/samples/javascript_nodejs/21.corebot-app-insights/index.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/index.js
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });

--- a/samples/javascript_nodejs/21.corebot-app-insights/index.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/index.js
@@ -91,8 +91,6 @@ server.post('/api/messages', (req, res) => {
 // Creates a new TelemetryClient based on a instrumentation key
 function getTelemetryClient(instrumentationKey) {
     if (instrumentationKey) {
-        const instrumentationKey = instrumentationKey.appInsights.instrumentationKey;
-
         return new ApplicationInsightsTelemetryClient(instrumentationKey);
     }
     return new NullTelemetryClient();

--- a/samples/javascript_nodejs/21.corebot-app-insights/index.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/index.js
@@ -17,6 +17,7 @@ const { FlightBookingRecognizer } = require('./dialogs/flightBookingRecognizer')
 const { DialogAndWelcomeBot } = require('./bots/dialogAndWelcomeBot');
 const { MainDialog } = require('./dialogs/mainDialog');
 const { BookingDialog } = require('./dialogs/bookingDialog');
+const BOOKING_DIALOG = 'bookingDialog';
 
 // Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
 const ENV_FILE = path.join(__dirname, '.env');

--- a/samples/javascript_nodejs/21.corebot-app-insights/models/errorViewModel.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/models/errorViewModel.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 class ErrorViewModel {
     constructor(requestId = null) {
         this.requestId = requestId;

--- a/samples/javascript_nodejs/21.corebot-app-insights/models/errorViewModel.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/models/errorViewModel.js
@@ -4,6 +4,6 @@ class ErrorViewModel {
     }
     
     showRequestId() {
-        return !this.requestId;
+        return Boolean(this.requestId);
     }
 }

--- a/samples/javascript_nodejs/21.corebot-app-insights/models/errorViewModel.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/models/errorViewModel.js
@@ -5,8 +5,10 @@ class ErrorViewModel {
     constructor(requestId = null) {
         this.requestId = requestId;
     }
-    
+
     showRequestId() {
         return Boolean(this.requestId);
     }
 }
+
+module.exports.ErrorViewModel = ErrorViewModel;

--- a/samples/javascript_nodejs/21.corebot-app-insights/models/errorViewModel.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/models/errorViewModel.js
@@ -1,0 +1,9 @@
+class ErrorViewModel {
+    constructor(requestId = null) {
+        this.requestId = requestId;
+    }
+    
+    showRequestId() {
+        return !this.requestId;
+    }
+}

--- a/samples/javascript_nodejs/21.corebot-app-insights/package.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/package.json
@@ -16,7 +16,10 @@
     "@microsoft/recognizers-text-data-types-timex-expression": "^1.1.4",
     "botbuilder": "^4.5.3",
     "botbuilder-ai": "^4.5.3",
+    "botbuilder-applicationinsights": "^4.5.3",
     "botbuilder-dialogs": "^4.5.3",
-    "dotenv": "^8.1.0"
+    "dotenv": "^8.1.0",
+    "path": "^0.12.7",
+    "restify": "^8.4.0"
   }
 }

--- a/samples/javascript_nodejs/21.corebot-app-insights/package.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "botbuilder": "^4.5.3",
+    "botbuilder-dialogs": "^4.5.3",
     "dotenv": "^8.1.0"
   }
 }

--- a/samples/javascript_nodejs/21.corebot-app-insights/package.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/package.json
@@ -13,6 +13,7 @@
   "author": "Microsoft",
   "license": "MIT",
   "dependencies": {
+    "botbuilder": "^4.5.3",
     "dotenv": "^8.1.0"
   }
 }

--- a/samples/javascript_nodejs/21.corebot-app-insights/package.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node ./index.js",
     "watch": "nodemon ./index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "eslint .",
+    "test": "nyc mocha tests/**/*.test.js"
   },
   "repository": {
     "type": "git",
@@ -21,6 +22,12 @@
     "botbuilder-applicationinsights": "^4.5.3",
     "botbuilder-dialogs": "^4.5.3",
     "dotenv": "^8.1.0",
+    "eslint": "^6.3.0",
+    "eslint-config-standard": "^14.1.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-node": "^10.0.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1",
     "nodemon": "^1.19.2",
     "path": "^0.12.7",
     "restify": "^8.4.0"

--- a/samples/javascript_nodejs/21.corebot-app-insights/package.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "corebot-app-insights",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
+  },
+  "author": "Microsoft",
+  "license": "MIT",
+  "dependencies": {
+    "dotenv": "^8.1.0"
+  }
+}

--- a/samples/javascript_nodejs/21.corebot-app-insights/package.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/package.json
@@ -13,7 +13,9 @@
   "author": "Microsoft",
   "license": "MIT",
   "dependencies": {
+    "@microsoft/recognizers-text-data-types-timex-expression": "^1.1.4",
     "botbuilder": "^4.5.3",
+    "botbuilder-ai": "^4.5.3",
     "botbuilder-dialogs": "^4.5.3",
     "dotenv": "^8.1.0"
   }

--- a/samples/javascript_nodejs/21.corebot-app-insights/package.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/package.json
@@ -1,9 +1,11 @@
 {
   "name": "corebot-app-insights",
   "version": "1.0.0",
-  "description": "",
+  "description": "A bot that demonstrates core AI capabilities with application insights.",
   "main": "index.js",
   "scripts": {
+    "start": "node ./index.js",
+    "watch": "nodemon ./index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -19,6 +21,7 @@
     "botbuilder-applicationinsights": "^4.5.3",
     "botbuilder-dialogs": "^4.5.3",
     "dotenv": "^8.1.0",
+    "nodemon": "^1.19.2",
     "path": "^0.12.7",
     "restify": "^8.4.0"
   }


### PR DESCRIPTION
## Proposed Changes
  - Add sample `21 - CoreBot with Application-Insights`, based on JS [Sample#13](https://github.com/microsoft/BotBuilder-Samples/tree/master/samples/javascript_nodejs/13.core-bot)

## More Information
This sample:
- Uses [LUIS](https://www.luis.ai) to implement core AI capabilities
- Implements a multi-turn conversation using Dialogs
- Handles user interruptions for such things as `Help` or `Cancel`
- Prompts for and validates requests for information from the user
- Uses [Application Insights](https://docs.microsoft.com/azure/azure-monitor/app/cloudservices) to monitor your bot

## Testing
To test this sample:
1. Clone this branch
1. In a terminal, navigate to `samples/javascript_nodejs/13.core-bot`
1. Install modules with `npm install`
1. Setup LUIS
1. Run the sample with `npm start`