### PR TITLE
Add test fix for NETCore 3.0

### DIFF
--- a/samples/csharp_dotnetcore/13.core-bot.tests/Bots/DialogBotTests.cs
+++ b/samples/csharp_dotnetcore/13.core-bot.tests/Bots/DialogBotTests.cs
@@ -43,7 +43,7 @@ namespace CoreBot.Tests.Bots
                     It.IsAny<EventId>(),
                     It.Is<object>(o => o.ToString() == "Running dialog with Message Activity."),
                     null,
-                    It.IsAny<Func<object, Exception, string>>()),
+                    (Func<object, Exception, string>)It.IsAny<object>()),
                 Times.Once);
         }
 


### PR DESCRIPTION
## Description
This fixes an issue when targeting **NETCore 3.0**, where one of the unit tests would fail.

## Proposed Changes
Due to an [issue ](https://github.com/moq/moq4/issues/918#issuecomment-527647423)with Moq and NETCore 3.0 we need to change the line `It.IsAny<Func<object, Exception, string>>()),` to `(Func<object, Exception, string>)It.IsAny<object>()),` in the [LogsInformationToILogger ](https://github.com/southworks/BotBuilder-Samples/blob/master/samples/csharp_dotnetcore/13.core-bot.tests/Bots/DialogBotTests.cs#L21)test for it to succeed under **NETCore 3.0**
