### PR TITLE
Add OAuth Card to the 06.using-cards samples

### DIFF
--- a/samples/csharp_dotnetcore/06.using-cards/Cards.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/Cards.cs
@@ -198,9 +198,9 @@ namespace Microsoft.BotBuilderSamples
         {
             var oauthCard = new OAuthCard
             {
-                Text = "Please, sign in",
+                Text = "BotFramework OAuth Card",
                 ConnectionName = "OAuth connection", // Replace with the name of your Azure AD connection.
-                Buttons = new List<CardAction> { new CardAction(ActionTypes.Signin, "Login", value: "https://example.org/signin") },
+                Buttons = new List<CardAction> { new CardAction(ActionTypes.Signin, "Sign In", value: "https://example.org/signin") },
             };
 
             return oauthCard;

--- a/samples/csharp_dotnetcore/06.using-cards/Cards.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/Cards.cs
@@ -193,5 +193,17 @@ namespace Microsoft.BotBuilderSamples
 
             return audioCard;
         }
+
+        public static OAuthCard GetOAuthCard()
+        {
+            var oauthCard = new OAuthCard
+            {
+                Text = "Please, sign in",
+                ConnectionName = "OAuth connection", // Replace with the name of your Azure AD connection.
+                Buttons = new List<CardAction> { new CardAction(ActionTypes.Signin, "Login", value: "https://example.org/signin") },
+            };
+
+            return oauthCard;
+        }
     }
 }

--- a/samples/csharp_dotnetcore/06.using-cards/Dialogs/MainDialog.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/Dialogs/MainDialog.cs
@@ -100,6 +100,10 @@ namespace Microsoft.BotBuilderSamples
                     // Display a VideoCard
                     reply.Attachments.Add(Cards.GetVideoCard().ToAttachment());
                     break;
+                case "OAuth Card":
+                    // Display an OAuthCard
+                    reply.Attachments.Add(Cards.GetOAuthCard().ToAttachment());
+                    break;
                 default:
                     // Display a carousel of all the rich card types.
                     reply.AttachmentLayout = AttachmentLayoutTypes.Carousel;
@@ -111,6 +115,7 @@ namespace Microsoft.BotBuilderSamples
                     reply.Attachments.Add(Cards.GetSigninCard().ToAttachment());
                     reply.Attachments.Add(Cards.GetThumbnailCard().ToAttachment());
                     reply.Attachments.Add(Cards.GetVideoCard().ToAttachment());
+                    reply.Attachments.Add(Cards.GetOAuthCard().ToAttachment());
                     break;
             }
 
@@ -135,6 +140,7 @@ namespace Microsoft.BotBuilderSamples
                 new Choice() { Value = "Signin Card", Synonyms = new List<string>() { "signin" } },
                 new Choice() { Value = "Thumbnail Card", Synonyms = new List<string>() { "thumbnail", "thumb" } },
                 new Choice() { Value = "Video Card", Synonyms = new List<string>() { "video" } },
+                new Choice() { Value = "OAuth Card", Synonyms = new List<string>() { "oauth" } },
                 new Choice() { Value = "All cards", Synonyms = new List<string>() { "all" } },
             };
 

--- a/samples/csharp_dotnetcore/06.using-cards/Dialogs/MainDialog.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/Dialogs/MainDialog.cs
@@ -84,6 +84,10 @@ namespace Microsoft.BotBuilderSamples
                     // Display a HeroCard.
                     reply.Attachments.Add(Cards.GetHeroCard().ToAttachment());
                     break;
+                case "OAuth Card":
+                    // Display an OAuthCard
+                    reply.Attachments.Add(Cards.GetOAuthCard().ToAttachment());
+                    break;
                 case "Receipt Card":
                     // Display a ReceiptCard.
                     reply.Attachments.Add(Cards.GetReceiptCard().ToAttachment());
@@ -100,10 +104,6 @@ namespace Microsoft.BotBuilderSamples
                     // Display a VideoCard
                     reply.Attachments.Add(Cards.GetVideoCard().ToAttachment());
                     break;
-                case "OAuth Card":
-                    // Display an OAuthCard
-                    reply.Attachments.Add(Cards.GetOAuthCard().ToAttachment());
-                    break;
                 default:
                     // Display a carousel of all the rich card types.
                     reply.AttachmentLayout = AttachmentLayoutTypes.Carousel;
@@ -111,11 +111,11 @@ namespace Microsoft.BotBuilderSamples
                     reply.Attachments.Add(Cards.GetAnimationCard().ToAttachment());
                     reply.Attachments.Add(Cards.GetAudioCard().ToAttachment());
                     reply.Attachments.Add(Cards.GetHeroCard().ToAttachment());
+                    reply.Attachments.Add(Cards.GetOAuthCard().ToAttachment());
                     reply.Attachments.Add(Cards.GetReceiptCard().ToAttachment());
                     reply.Attachments.Add(Cards.GetSigninCard().ToAttachment());
                     reply.Attachments.Add(Cards.GetThumbnailCard().ToAttachment());
                     reply.Attachments.Add(Cards.GetVideoCard().ToAttachment());
-                    reply.Attachments.Add(Cards.GetOAuthCard().ToAttachment());
                     break;
             }
 
@@ -136,11 +136,11 @@ namespace Microsoft.BotBuilderSamples
                 new Choice() { Value = "Animation Card", Synonyms = new List<string>() { "animation" } },
                 new Choice() { Value = "Audio Card", Synonyms = new List<string>() { "audio" } },
                 new Choice() { Value = "Hero Card", Synonyms = new List<string>() { "hero" } },
+                new Choice() { Value = "OAuth Card", Synonyms = new List<string>() { "oauth" } },
                 new Choice() { Value = "Receipt Card", Synonyms = new List<string>() { "receipt" } },
                 new Choice() { Value = "Signin Card", Synonyms = new List<string>() { "signin" } },
                 new Choice() { Value = "Thumbnail Card", Synonyms = new List<string>() { "thumbnail", "thumb" } },
                 new Choice() { Value = "Video Card", Synonyms = new List<string>() { "video" } },
-                new Choice() { Value = "OAuth Card", Synonyms = new List<string>() { "oauth" } },
                 new Choice() { Value = "All cards", Synonyms = new List<string>() { "all" } },
             };
 

--- a/samples/javascript_nodejs/06.using-cards/dialogs/mainDialog.js
+++ b/samples/javascript_nodejs/06.using-cards/dialogs/mainDialog.js
@@ -81,6 +81,9 @@ class MainDialog extends ComponentDialog {
         case 'Hero Card':
             await stepContext.context.sendActivity({ attachments: [this.createHeroCard()] });
             break;
+        case 'OAuth Card':
+            await stepContext.context.sendActivity({ attachments: [this.createOAuthCard()] });
+            break;
         case 'Receipt Card':
             await stepContext.context.sendActivity({ attachments: [this.createReceiptCard()] });
             break;
@@ -100,6 +103,7 @@ class MainDialog extends ComponentDialog {
                     this.createAnimationCard(),
                     this.createAudioCard(),
                     this.createHeroCard(),
+                    this.createOAuthCard(),
                     this.createReceiptCard(),
                     this.createSignInCard(),
                     this.createThumbnailCard(),
@@ -133,6 +137,10 @@ class MainDialog extends ComponentDialog {
             {
                 value: 'Audio Card',
                 synonyms: ['audio']
+            },
+            {
+                value: 'OAuth Card',
+                synonyms: ['oauth']
             },
             {
                 value: 'Hero Card',
@@ -214,6 +222,14 @@ class MainDialog extends ComponentDialog {
                     value: 'https://docs.microsoft.com/en-us/azure/bot-service/'
                 }
             ])
+        );
+    }
+
+    createOAuthCard() {
+        return CardFactory.oauthCard(
+            'OAuth connection', // Replace with the name of your Azure AD connection
+            'Sign In',
+            'BotFramework OAuth Card'
         );
     }
 

--- a/samples/python/06.using-cards/dialogs/main_dialog.py
+++ b/samples/python/06.using-cards/dialogs/main_dialog.py
@@ -302,7 +302,7 @@ class MainDialog(ComponentDialog):
             Choice(value="Animation Card", synonyms=["animation"]),
             Choice(value="Audio Card", synonyms=["audio"]),
             Choice(value="Hero Card", synonyms=["hero"]),
-            Choice(value="OAuth Card", synonyms=["auth"]),
+            Choice(value="OAuth Card", synonyms=["oauth"]),
             Choice(value="Receipt Card", synonyms=["receipt"]),
             Choice(value="Signin Card", synonyms=["signin"]),
             Choice(value="Thumbnail Card", synonyms=["thumbnail", "thumb"]),

--- a/samples/python/06.using-cards/dialogs/main_dialog.py
+++ b/samples/python/06.using-cards/dialogs/main_dialog.py
@@ -185,7 +185,7 @@ class MainDialog(ComponentDialog):
     def create_oauth_card(self) -> Attachment:
         card = OAuthCard(
             text="BotFramework OAuth Card",
-            connection_name="OAuth connection",
+            connection_name="OAuth connection", # Replace it with the name of your Azure AD connection.
             buttons=[
                 CardAction(
                     type=ActionTypes.signin,

--- a/samples/python/06.using-cards/dialogs/main_dialog.py
+++ b/samples/python/06.using-cards/dialogs/main_dialog.py
@@ -16,6 +16,7 @@ from botbuilder.schema import (
     AnimationCard,
     AudioCard,
     HeroCard,
+    OAuthCard,
     VideoCard,
     ReceiptCard,
     SigninCard,
@@ -92,6 +93,8 @@ class MainDialog(ComponentDialog):
             reply.attachments.append(self.create_audio_card())
         elif found_choice == "Hero Card":
             reply.attachments.append(self.create_hero_card())
+        elif found_choice == "OAuth Card":
+            reply.attachments.append(self.create_oauth_card())
         elif found_choice == "Receipt Card":
             reply.attachments.append(self.create_receipt_card())
         elif found_choice == "Signin Card":
@@ -106,6 +109,7 @@ class MainDialog(ComponentDialog):
             reply.attachments.append(self.create_animation_card())
             reply.attachments.append(self.create_audio_card())
             reply.attachments.append(self.create_hero_card())
+            reply.attachments.append(self.create_oauth_card())
             reply.attachments.append(self.create_receipt_card())
             reply.attachments.append(self.create_signin_card())
             reply.attachments.append(self.create_thumbnail_card())
@@ -177,6 +181,20 @@ class MainDialog(ComponentDialog):
             ],
         )
         return CardFactory.hero_card(card)
+
+    def create_oauth_card(self) -> Attachment:
+        card = OAuthCard(
+            text="BotFramework OAuth Card",
+            connection_name="test.com",
+            buttons=[
+                CardAction(
+                    type=ActionTypes.signin,
+                    title="Sign in",
+                    value="https://example.org/signin",
+                )
+            ],
+        )
+        return CardFactory.oauth_card(card)
 
     def create_video_card(self) -> Attachment:
         card = VideoCard(
@@ -284,6 +302,7 @@ class MainDialog(ComponentDialog):
             Choice(value="Animation Card", synonyms=["animation"]),
             Choice(value="Audio Card", synonyms=["audio"]),
             Choice(value="Hero Card", synonyms=["hero"]),
+            Choice(value="OAuth Card", synonyms=["auth"]),
             Choice(value="Receipt Card", synonyms=["receipt"]),
             Choice(value="Signin Card", synonyms=["signin"]),
             Choice(value="Thumbnail Card", synonyms=["thumbnail", "thumb"]),

--- a/samples/python/06.using-cards/dialogs/main_dialog.py
+++ b/samples/python/06.using-cards/dialogs/main_dialog.py
@@ -185,7 +185,7 @@ class MainDialog(ComponentDialog):
     def create_oauth_card(self) -> Attachment:
         card = OAuthCard(
             text="BotFramework OAuth Card",
-            connection_name="test.com",
+            connection_name="OAuth connection",
             buttons=[
                 CardAction(
                     type=ActionTypes.signin,

--- a/samples/typescript_nodejs/06.using-cards/src/dialogs/mainDialog.ts
+++ b/samples/typescript_nodejs/06.using-cards/src/dialogs/mainDialog.ts
@@ -86,6 +86,9 @@ export class MainDialog extends ComponentDialog {
             case 'Audio Card':
                 await stepContext.context.sendActivity({ attachments: [this.createAudioCard()] });
                 break;
+            case 'OAuth Card':
+                await stepContext.context.sendActivity({ attachments: [this.createOAuthCard()] });
+                break;
             case 'Hero Card':
                 await stepContext.context.sendActivity({ attachments: [this.createHeroCard()] });
                 break;
@@ -108,6 +111,7 @@ export class MainDialog extends ComponentDialog {
                         this.createAdaptiveCard(),
                         this.createAnimationCard(),
                         this.createAudioCard(),
+                        this.createOAuthCard(),
                         this.createHeroCard(),
                         this.createReceiptCard(),
                         this.createSignInCard(),
@@ -145,6 +149,10 @@ export class MainDialog extends ComponentDialog {
             {
                 synonyms: ['hero'],
                 value: 'Hero Card'
+            },
+            {
+                synonyms: ['oauth'],
+                value: 'OAuth Card'
             },
             {
                 synonyms: ['receipt'],
@@ -208,6 +216,14 @@ export class MainDialog extends ComponentDialog {
                 subtitle: 'Star Wars: Episode V - The Empire Strikes Back',
                 text: 'The Empire Strikes Back (also known as Star Wars: Episode V – The Empire Strikes Back) is a 1980 American epic space opera film directed by Irvin Kershner. Leigh Brackett and Lawrence Kasdan wrote the screenplay, with George Lucas writing the film\'s story and serving as executive producer. The second installment in the original Star Wars trilogy, it was produced by Gary Kurtz for Lucasfilm Ltd. and stars Mark Hamill, Harrison Ford, Carrie Fisher, Billy Dee Williams, Anthony Daniels, David Prowse, Kenny Baker, Peter Mayhew and Frank Oz.'
             }
+        );
+    }
+
+    private createOAuthCard() {
+        return CardFactory.oauthCard(
+            'OAuth connection', // Replace with the name of your Azure AD connection
+            'Sign In',
+            'BotFramework OAuth Card'
         );
     }
 


### PR DESCRIPTION
Fixes ISSUE#2517

## Description
- Add the **OAuthCard** to the **06.using-card** sample for [Dotnet](https://github.com/microsoft/BotBuilder-Samples/tree/master/samples/csharp_dotnetcore/06.using-cards), [Javascript](https://github.com/microsoft/BotBuilder-Samples/tree/master/samples/javascript_nodejs/06.using-cards), [Typescript](https://github.com/microsoft/BotBuilder-Samples/tree/master/samples/typescript_nodejs/06.using-cards) and [Python](https://github.com/microsoft/BotBuilder-Samples/tree/master/samples/python/06.using-cards).

## Changes made
We modified the **main dialog** to add a method that creates the **OAuth card** as an attachment and added the references to this method in all the choice options.
These changes were made for each language in which the **06.using-card** sample exists.

## Testing
In the image below we can see the **06.using-card** sample using the **OAuthCard** as an attachment.

![image](https://user-images.githubusercontent.com/44245136/85143587-50a66080-b220-11ea-85c6-8b13bc9543d4.png)

