### PR TITLE
[Samples][Java] Fix disparities of 25.message-reaction sample

### DIFF
--- a/samples/java_springboot/25.message-reaction/README.md
+++ b/samples/java_springboot/25.message-reaction/README.md
@@ -126,11 +126,5 @@ After the bot is deployed, you only need to execute #6 if you make changes to th
 
 - [Spring Boot](https://spring.io/projects/spring-boot)
 - [Maven Plugin for Azure App Service](https://github.com/microsoft/azure-maven-plugins/tree/develop/azure-webapp-maven-plugin)
-- [Bot Basics](https://docs.microsoft.com/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
-- [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
-- [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
-- [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
-- [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
-- [Azure Portal](https://portal.azure.com)
 - [Azure for Java cloud developers](https://docs.microsoft.com/en-us/azure/java/?view=azure-java-stable)
 - [Teams Message Reaction Events](https://docs.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/subscribe-to-conversation-events?tabs=dotnet#message-reaction-events)

--- a/samples/java_springboot/25.message-reaction/README.md
+++ b/samples/java_springboot/25.message-reaction/README.md
@@ -1,14 +1,14 @@
 ## Message Reactions Bot
 
+Bot Framework v4 core bot sample.
+
 Bot Framework [message reactions](https://docs.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/subscribe-to-conversation-events?tabs=dotnet#message-reaction-events) bot sample.
 
 This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to create a simple bot that responds to Message Reactions.
 
+This sample is a Spring Boot app and uses the Azure CLI and azure-webapp Maven plugin to deploy to Azure.
+
 ## Prerequisites
-
-This samples **requires** prerequisites in order to run.
-
-### Overview
 
 - Java 1.8+
 - Install [Maven](https://maven.apache.org/)
@@ -40,8 +40,6 @@ the Teams service needs to call into the bot.
 
 1) Update the `resources/application.properties` configuration for the bot to use the Microsoft App Id and App Password from the Bot Framework registration. (Note the App Password is referred to as the "client secret" in the azure portal and you can always create a new client secret anytime.)
 
-1) Update `CustomForm.html` to replace your Microsoft App Id *everywhere* you see the place holder string `<<YOUR-MICROSOFT-APP-ID>>`
-
 1) __*This step is specific to Teams.*__
     - **Edit** the `manifest.json` contained in the `teamsAppManifest` folder to replace your Microsoft App Id (that was created when you registered your bot earlier) *everywhere* you see the place holder string `<<YOUR-MICROSOFT-APP-ID>>` (depending on the scenario the Microsoft App Id may occur multiple times in the `manifest.json`). **Note:** the Task Modules containing pages will require the deployed bot's domain in validDomains of the manifest.
     - **Zip** up the contents of the `teamsAppManifest` folder to create a `manifest.zip`
@@ -51,13 +49,7 @@ the Teams service needs to call into the bot.
     - Build the sample using `mvn package`
     - Unless done previously, install the packages in the local cache by using `mvn install`
     - Run it by using `java -jar .\target\bot-messagereaction-sample.jar`
-
-## Testing the bot using Bot Framework Emulator
-
-[Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
-
-- Install the latest Bot Framework Emulator from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
-
+    
 ### Connect to the bot using Bot Framework Emulator
 
 - Launch Bot Framework Emulator
@@ -70,8 +62,75 @@ Message the bot and it will respond with an 'Echo: [your message]'.  Add a messa
 
 ## Deploy the bot to Azure
 
-To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.
+As described on [Deploy your bot](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-deploy-az-cli), you will perform the first 4 steps to setup the Azure app, then deploy the code using the azure-webapp Maven plugin.
+
+### 1. Login to Azure
+
+From a command (or PowerShell) prompt in the root of the bot folder, execute:
+`az login`
+
+### 2. Set the subscription
+
+```
+az account set --subscription "<azure-subscription>"
+```
+
+If you aren't sure which subscription to use for deploying the bot,  you can view the list of subscriptions for your account by using `az account list` command.
+
+### 3. Create an App registration
+
+```
+az ad app create --display-name "<botname>" --password "<appsecret>" --available-to-other-tenants
+```
+
+Replace `<botname>` and `<appsecret>` with your own values.
+
+`<botname>` is the unique name of your bot.
+`<appsecret>` is a minimum 16 character password for your bot.
+
+Record the `appid` from the returned JSON
+
+### 4. Create the Azure resources
+
+Replace the values for `<appid>`, `<appsecret>`, `<botname>`, and `<groupname>` in the following commands:
+
+#### To a new Resource Group
+
+```
+az deployment sub create --name "messageReactionBotDeploy" --location "westus" --template-file ".\deploymentTemplates\template-with-new-rg.json" --parameters appId="<appid>" appSecret="<appsecret>" botId="<botname>" botSku=S1 newAppServicePlanName="messageReactionBotPlan" newWebAppName="messageReactionBot" groupLocation="westus" newAppServicePlanLocation="westus"
+```
+
+#### To an existing Resource Group
+
+```
+az deployment group create --resource-group "<groupname>" --template-file ".\deploymentTemplates\template-with-preexisting-rg.json" --parameters appId="<appid>" appSecret="<appsecret>" botId="<botname>" newWebAppName="messageReactionBot" newAppServicePlanName="messageReactionBotPlan" appServicePlanLocation="westus" --name "messageReactionBot"
+```
+
+### 5. Update app id and password
+
+In src/main/resources/application.properties update
+
+- `MicrosoftAppPassword` with the botsecret value
+- `MicrosoftAppId` with the appid from the first step
+
+### 6. Deploy the code
+
+- Execute `mvn clean package`
+- Execute `mvn azure-webapp:deploy -Dgroupname="<groupname>" -Dbotname="<bot-app-service-name>"`
+
+If the deployment is successful, you will be able to test it via  "Test in Web Chat" from the Azure Portal using the "Bot Channel  Registration" for the bot.
+
+After the bot is deployed, you only need to execute #6 if you make changes to the bot.
 
 ## Further reading
 
+- [Spring Boot](https://spring.io/projects/spring-boot)
+- [Maven Plugin for Azure App Service](https://github.com/microsoft/azure-maven-plugins/tree/develop/azure-webapp-maven-plugin)
+- [Bot Basics](https://docs.microsoft.com/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
+- [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
+- [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
+- [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
+- [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
+- [Azure Portal](https://portal.azure.com)
+- [Azure for Java cloud developers](https://docs.microsoft.com/en-us/azure/java/?view=azure-java-stable)
 - [Teams Message Reaction Events](https://docs.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/subscribe-to-conversation-events?tabs=dotnet#message-reaction-events)

--- a/samples/java_springboot/25.message-reaction/target/classes/application.properties
+++ b/samples/java_springboot/25.message-reaction/target/classes/application.properties
@@ -1,3 +1,0 @@
-MicrosoftAppId=
-MicrosoftAppPassword=
-server.port=3978

--- a/samples/java_springboot/25.message-reaction/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
+++ b/samples/java_springboot/25.message-reaction/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
@@ -1,3 +1,0 @@
-com\microsoft\bot\sample\messagereaction\Application.class
-com\microsoft\bot\sample\messagereaction\MessageReactionBot.class
-com\microsoft\bot\sample\messagereaction\ActivityLog.class

--- a/samples/java_springboot/25.message-reaction/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
+++ b/samples/java_springboot/25.message-reaction/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
@@ -1,4 +1,0 @@
-H:\BotFramework\botbuilder-java\samples\25.message-reaction\src\main\java\com\microsoft\bot\sample\messagereaction\MessageReactionBot.java
-H:\BotFramework\botbuilder-java\samples\25.message-reaction\src\main\java\com\microsoft\bot\sample\messagereaction\Application.java
-H:\BotFramework\botbuilder-java\samples\25.message-reaction\src\main\java\com\microsoft\bot\sample\messagereaction\ActivityLog.java
-H:\BotFramework\botbuilder-java\samples\25.message-reaction\src\main\java\com\microsoft\bot\sample\messagereaction\package-info.java


### PR DESCRIPTION
Related to microsoft/botbuilder-java1165

## Proposed Changes
We compared the documentation/code migration/behavior of the `25.message-reaction` sample between [Java](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/java_springboot/25.message-reaction) and [C#](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/csharp_dotnetcore/25.message-reaction) and we found disparities and fixes that this PR includes.

- Update README
- Clean-up autogenerated files/folder related to Eclipse (e.g. target/.classpath)

## Testing
_Message Reaction sample working as expected_
![eod teams](https://user-images.githubusercontent.com/64086728/117202653-6f73fe00-adc4-11eb-90dc-007d3fdf47d6.png)