### PR TITLE
[Java][13.core-bot] Add missing dependecy

### DIFF
--- a/samples/java_springboot/13.core-bot/pom.xml
+++ b/samples/java_springboot/13.core-bot/pom.xml
@@ -105,6 +105,11 @@
         <artifactId>bot-ai-luis-v3</artifactId>
         <version>4.13.0</version>
       </dependency>
+      <dependency>
+        <groupId>com.microsoft.bot</groupId>
+        <artifactId>bot-applicationinsights</artifactId>
+        <version>4.13.0</version>
+      </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
When testing the sample with the new cloudAdapter we found an error on the imports related to the applicationInsights dependency not being present.

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - Add bot-applicationinsights dependency to the pom.xml

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->