### PR TITLE
[Java][21.corebot-app-insights] Updated CloudAdapterWithErrorHandler constructor initialization

### DIFF
--- a/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/Application.java
+++ b/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/Application.java
@@ -94,8 +94,6 @@ public class Application extends BotDependencyConfiguration {
 
         CloudAdapterWithErrorHandler adapter = new CloudAdapterWithErrorHandler(
             configuration,
-            telemetryInitializerMiddleware,
-            botTelemetryClient,
             conversationState);
 
         return adapter;

--- a/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/Application.java
+++ b/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/Application.java
@@ -12,7 +12,6 @@ import com.microsoft.bot.builder.NullBotTelemetryClient;
 import com.microsoft.bot.builder.Storage;
 import com.microsoft.bot.builder.TelemetryLoggerMiddleware;
 import com.microsoft.bot.builder.UserState;
-import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
 import com.microsoft.bot.integration.spring.BotController;
@@ -94,6 +93,8 @@ public class Application extends BotDependencyConfiguration {
 
         CloudAdapterWithErrorHandler adapter = new CloudAdapterWithErrorHandler(
             configuration,
+            telemetryInitializerMiddleware,
+            botTelemetryClient,
             conversationState);
 
         return adapter;

--- a/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/CloudAdapterWithErrorHandler.java
+++ b/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/CloudAdapterWithErrorHandler.java
@@ -71,23 +71,23 @@ public class CloudAdapterWithErrorHandler extends CloudAdapter {
 
             // Send a message to the user
             return turnContext.sendActivities(
-                    MessageFactory.text(ERROR_MSG_ONE), MessageFactory.text(ERROR_MSG_TWO)
+                MessageFactory.text(ERROR_MSG_ONE), MessageFactory.text(ERROR_MSG_TWO)
             ).thenCompose(resourceResponse -> sendTraceActivity(turnContext, exception))
-                    .thenCompose(stageResult -> {
-                        if (withConversationState != null) {
-                            // Delete the conversationState for the current conversation to prevent the
-                            // bot from getting stuck in a error-loop caused by being in a bad state.
-                            // ConversationState should be thought of as similar to "cookie-state" in a
-                            // Web pages.
-                            return withConversationState.delete(turnContext)
-                                    .exceptionally(deleteException -> {
-                                        LoggerFactory.getLogger(CloudAdapterWithErrorHandler.class)
-                                                .error("ConversationState.delete", deleteException);
-                                        return null;
-                                    });
-                        }
-                        return CompletableFuture.completedFuture(null);
-                    });
+                .thenCompose(stageResult -> {
+                    if (withConversationState != null) {
+                        // Delete the conversationState for the current conversation to prevent the
+                        // bot from getting stuck in a error-loop caused by being in a bad state.
+                        // ConversationState should be thought of as similar to "cookie-state" in a
+                        // Web pages.
+                        return withConversationState.delete(turnContext)
+                            .exceptionally(deleteException -> {
+                                LoggerFactory.getLogger(CloudAdapterWithErrorHandler.class)
+                                    .error("ConversationState.delete", deleteException);
+                                return null;
+                            });
+                    }
+                    return CompletableFuture.completedFuture(null);
+                });
         });
     }
 

--- a/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/CloudAdapterWithErrorHandler.java
+++ b/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/CloudAdapterWithErrorHandler.java
@@ -9,7 +9,7 @@ import com.microsoft.bot.builder.ConversationState;
 import com.microsoft.bot.builder.MessageFactory;
 import com.microsoft.bot.builder.TurnContext;
 import com.microsoft.bot.connector.Channels;
-import com.microsoft.bot.integration.BotFrameworkHttpAdapter;
+import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
 import com.microsoft.bot.schema.Activity;
 import com.microsoft.bot.schema.ActivityTypes;
@@ -25,12 +25,10 @@ import java.util.concurrent.CompletableFuture;
 /**
  * An Adapter that provides exception handling.
  */
-public class AdapterWithErrorHandler extends BotFrameworkHttpAdapter {
-
+public class CloudAdapterWithErrorHandler extends CloudAdapter {
     private static final String ERROR_MSG_ONE = "The bot encountered an error or bug.";
     private static final String ERROR_MSG_TWO =
-        "To continue to run this bot, please fix the bot source code.";
-    // Create field for telemetry client. Add IBotTelemetryClient parameter to AdapterWithErrorHandler
+            "To continue to run this bot, please fix the bot source code.";
     private BotTelemetryClient adapterBotTelemetryClient;
 
     /**
@@ -47,11 +45,10 @@ public class AdapterWithErrorHandler extends BotFrameworkHttpAdapter {
      * @param botTelemetryClient The BotTelemetryClient object to use.
      * @param withConversationState The ConversationState object to use.
      */
-    public AdapterWithErrorHandler(
-        Configuration withConfiguration,
-        TelemetryInitializerMiddleware telemetryInitializerMiddleware,
-        BotTelemetryClient botTelemetryClient,
-        @Nullable ConversationState withConversationState) {
+    public CloudAdapterWithErrorHandler(Configuration withConfiguration,
+                                        TelemetryInitializerMiddleware telemetryInitializerMiddleware,
+                                        BotTelemetryClient botTelemetryClient,
+                                        @Nullable ConversationState withConversationState) {
         super(withConfiguration);
         this.use(telemetryInitializerMiddleware);
 
@@ -70,33 +67,33 @@ public class AdapterWithErrorHandler extends BotFrameworkHttpAdapter {
             // NOTE: In production environment, you should consider logging this to
             // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
             // to add telemetry capture to your bot.
-            LoggerFactory.getLogger(AdapterWithErrorHandler.class).error("onTurnError", exception);
+            LoggerFactory.getLogger(CloudAdapterWithErrorHandler.class).error("onTurnError", exception);
 
             // Send a message to the user
             return turnContext.sendActivities(
-                MessageFactory.text(ERROR_MSG_ONE), MessageFactory.text(ERROR_MSG_TWO)
+                    MessageFactory.text(ERROR_MSG_ONE), MessageFactory.text(ERROR_MSG_TWO)
             ).thenCompose(resourceResponse -> sendTraceActivity(turnContext, exception))
-                .thenCompose(stageResult -> {
-                    if (withConversationState != null) {
-                        // Delete the conversationState for the current conversation to prevent the
-                        // bot from getting stuck in a error-loop caused by being in a bad state.
-                        // ConversationState should be thought of as similar to "cookie-state" in a
-                        // Web pages.
-                        return withConversationState.delete(turnContext)
-                            .exceptionally(deleteException -> {
-                                LoggerFactory.getLogger(AdapterWithErrorHandler.class)
-                                    .error("ConversationState.delete", deleteException);
-                                return null;
-                            });
-                    }
-                    return CompletableFuture.completedFuture(null);
-                });
+                    .thenCompose(stageResult -> {
+                        if (withConversationState != null) {
+                            // Delete the conversationState for the current conversation to prevent the
+                            // bot from getting stuck in a error-loop caused by being in a bad state.
+                            // ConversationState should be thought of as similar to "cookie-state" in a
+                            // Web pages.
+                            return withConversationState.delete(turnContext)
+                                    .exceptionally(deleteException -> {
+                                        LoggerFactory.getLogger(CloudAdapterWithErrorHandler.class)
+                                                .error("ConversationState.delete", deleteException);
+                                        return null;
+                                    });
+                        }
+                        return CompletableFuture.completedFuture(null);
+                    });
         });
     }
 
     private CompletableFuture<Void> sendTraceActivity(
-        TurnContext turnContext,
-        Throwable exception
+            TurnContext turnContext,
+            Throwable exception
     ) {
         if (StringUtils.equals(turnContext.getActivity().getChannelId(), Channels.EMULATOR)) {
             Activity traceActivity = new Activity(ActivityTypes.TRACE);
@@ -105,7 +102,6 @@ public class AdapterWithErrorHandler extends BotFrameworkHttpAdapter {
             traceActivity.setValue(ExceptionUtils.getStackTrace(exception));
             traceActivity.setValueType("https://www.botframework.com/schemas/error");
 
-            // Send a trace activity, which will be displayed in the Bot Framework Emulator
             return turnContext.sendActivity(traceActivity).thenApply(resourceResponse -> null);
         }
 


### PR DESCRIPTION
We found an error when trying to compile the sample **_21.corebot-app-insights_**:

![imagen](https://user-images.githubusercontent.com/62261539/126221412-18fbd243-f0a9-4b35-9e53-1aa1e45e59ea.png)

## Proposed Changes
  - Added CloudAdapterWithErrorHandler class to include a constructor for logging to AppInsights when an error is thrown
  - Removed unused class AdapterWithErrorHandler

## Testing
Sample compiled successfully

![imagen](https://user-images.githubusercontent.com/62261539/126220926-5cc39fa0-f1eb-4059-8f61-a47bb9bff937.png)

