### PR TITLE
Added a comment explaining a failing condition

### DIFF
--- a/samples/java_springboot/42.scaleout/src/main/java/com/microsoft/bot/sample/scaleout/ScaleoutBot.java
+++ b/samples/java_springboot/42.scaleout/src/main/java/com/microsoft/bot/sample/scaleout/ScaleoutBot.java
@@ -62,7 +62,10 @@ public class ScaleoutBot<T extends Dialog> extends ActivityHandler {
 
         final Boolean[] shouldBreak = {false};
         String finalKey = key;
-        // The execution sits in a loop because there might be a retry if the save operation fails.
+        /**
+        * The execution sits in a loop because there might be a retry if the save operation fails.
+        * The task will fail when running locally with an AD App configured (MicrosoftAppId/MicrosoftAppPassword)
+        */
         while (true) {
             // Load any existing state associated with this key
             CompletableFuture<Pair<JsonNode, String>> saveTask = store.load(finalKey).thenCompose(pairOldState -> {

--- a/samples/java_springboot/42.scaleout/src/main/java/com/microsoft/bot/sample/scaleout/ScaleoutBot.java
+++ b/samples/java_springboot/42.scaleout/src/main/java/com/microsoft/bot/sample/scaleout/ScaleoutBot.java
@@ -64,7 +64,7 @@ public class ScaleoutBot<T extends Dialog> extends ActivityHandler {
         String finalKey = key;
         /**
         * The execution sits in a loop because there might be a retry if the save operation fails.
-        * The task will fail when running locally with an AD App configured (MicrosoftAppId/MicrosoftAppPassword)
+        * The task will fail when running locally with an App Registration configured (MicrosoftAppId/MicrosoftAppPassword)
         */
         while (true) {
             // Load any existing state associated with this key


### PR DESCRIPTION
## Description
The sample 42 (ScaleOut) fails when running locally using `java -jar path_to_jar_file.jar` if `MicrosoftAppId` and `MicrosoftAppPassword` are configured. 

This seems to be related with the use of `CompleatableFuture` which is launching a thread and then joining it back to the main one. 
I found a [workaround](https://stackoverflow.com/questions/49113207/completablefuture-forkjoinpool-set-class-loader) to set the context class loader for the forked threads. I assume that this may work, but adds a lot of unnecessary overhead
Given this context, and knowing that is an uncommon configuration, I'd chose to avoid making changes and added a comment stating that this wont work if configured this way.