### PR TITLE
Added missing import to enable using BlobStorage and CosmosDB to sample 45

### DIFF
--- a/samples/java_springboot/45.state-management/src/main/java/com/microsoft/bot/sample/statemanagement/Application.java
+++ b/samples/java_springboot/45.state-management/src/main/java/com/microsoft/bot/sample/statemanagement/Application.java
@@ -8,6 +8,7 @@ import com.microsoft.bot.azure.CosmosDbPartitionedStorageOptions;
 import com.microsoft.bot.azure.blobs.BlobsStorage;
 import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.builder.ConversationState;
+import com.microsoft.bot.builder.Storage;
 import com.microsoft.bot.builder.UserState;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;


### PR DESCRIPTION
## Description
When configuring the solution to run using `BlobStorage` or `CosmosDB` as state storage method, the build failed caused by a missing reference.

![image](https://user-images.githubusercontent.com/58704965/126500515-7b3f6dff-c87b-4104-9886-c05512b68b92.png)

## Specific changes
- Added missing import 