### PR TITLE
[Java][samples] Implement changes to ensure consistency accessing local resources on all samples

### DIFF
--- a/generators/java/generators/app/templates/core/src/main/java/DialogAndWelcomeBot.java
+++ b/generators/java/generators/app/templates/core/src/main/java/DialogAndWelcomeBot.java
@@ -78,11 +78,9 @@ public class DialogAndWelcomeBot<T extends Dialog> extends DialogBot {
 
     // Load attachment from embedded resource.
     private Attachment createAdaptiveCardAttachment() {
-        Attachment adaptiveCardAttachment = new Attachment();
-
         try (
-            InputStream inputStream = adaptiveCardAttachment.getClass().getClassLoader()
-                .getResourceAsStream("cards/welcomeCard.json")
+            InputStream inputStream = Thread.currentThread().
+                getContextClassLoader().getResourceAsStream("cards/welcomeCard.json")
         ) {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());

--- a/generators/java/generators/app/templates/core/src/main/java/DialogAndWelcomeBot.java
+++ b/generators/java/generators/app/templates/core/src/main/java/DialogAndWelcomeBot.java
@@ -78,9 +78,11 @@ public class DialogAndWelcomeBot<T extends Dialog> extends DialogBot {
 
     // Load attachment from embedded resource.
     private Attachment createAdaptiveCardAttachment() {
+        Attachment adaptiveCardAttachment = new Attachment();
+
         try (
-            InputStream inputStream = Thread.currentThread().
-                getContextClassLoader().getResourceAsStream("cards/welcomeCard.json")
+            InputStream inputStream = adaptiveCardAttachment.getClass().getClassLoader()
+                .getResourceAsStream("cards/welcomeCard.json")
         ) {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());

--- a/samples/java_springboot/07.using-adaptive-cards/src/main/java/com/microsoft/bot/sample/usingadaptivecards/AdaptiveCardsBot.java
+++ b/samples/java_springboot/07.using-adaptive-cards/src/main/java/com/microsoft/bot/sample/usingadaptivecards/AdaptiveCardsBot.java
@@ -86,9 +86,11 @@ public class AdaptiveCardsBot extends ActivityHandler {
     }
 
     private static Attachment createAdaptiveCardAttachment(String filePath) {
+        Attachment adaptiveCardAttachment = new Attachment();
+
         try (
-            InputStream inputStream = Thread.currentThread().
-                getContextClassLoader().getResourceAsStream(filePath)
+            InputStream inputStream = adaptiveCardAttachment.getClass()
+                .getClassLoader().getResourceAsStream(filePath)
         ) {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());

--- a/samples/java_springboot/07.using-adaptive-cards/src/main/java/com/microsoft/bot/sample/usingadaptivecards/AdaptiveCardsBot.java
+++ b/samples/java_springboot/07.using-adaptive-cards/src/main/java/com/microsoft/bot/sample/usingadaptivecards/AdaptiveCardsBot.java
@@ -86,16 +86,16 @@ public class AdaptiveCardsBot extends ActivityHandler {
     }
 
     private static Attachment createAdaptiveCardAttachment(String filePath) {
-        Attachment adaptiveCardAttachment = new Attachment();
+        Attachment attachment = null;
 
         try (
-            InputStream inputStream = adaptiveCardAttachment.getClass()
+            InputStream inputStream = attachment.getClass()
                 .getClassLoader().getResourceAsStream(filePath)
         ) {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());
 
-            Attachment attachment = new Attachment();
+            attachment = new Attachment();
             attachment.setContentType("application/vnd.microsoft.card.adaptive");
             attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
 

--- a/samples/java_springboot/13.core-bot/src/main/java/com/microsoft/bot/sample/core/DialogAndWelcomeBot.java
+++ b/samples/java_springboot/13.core-bot/src/main/java/com/microsoft/bot/sample/core/DialogAndWelcomeBot.java
@@ -78,9 +78,11 @@ public class DialogAndWelcomeBot<T extends Dialog> extends DialogBot {
 
     // Load attachment from embedded resource.
     private Attachment createAdaptiveCardAttachment() {
+        Attachment adaptiveCardAttachment = new Attachment();
+
         try (
-            InputStream inputStream = Thread.currentThread().
-                getContextClassLoader().getResourceAsStream("cards/welcomeCard.json")
+            InputStream inputStream = adaptiveCardAttachment.getClass()
+                .getClassLoader().getResourceAsStream("cards/welcomeCard.json")
         ) {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());

--- a/samples/java_springboot/13.core-bot/src/main/java/com/microsoft/bot/sample/core/DialogAndWelcomeBot.java
+++ b/samples/java_springboot/13.core-bot/src/main/java/com/microsoft/bot/sample/core/DialogAndWelcomeBot.java
@@ -78,16 +78,16 @@ public class DialogAndWelcomeBot<T extends Dialog> extends DialogBot {
 
     // Load attachment from embedded resource.
     private Attachment createAdaptiveCardAttachment() {
-        Attachment adaptiveCardAttachment = new Attachment();
+        Attachment attachment = null;
 
         try (
-            InputStream inputStream = adaptiveCardAttachment.getClass()
+            InputStream inputStream = attachment.getClass()
                 .getClassLoader().getResourceAsStream("cards/welcomeCard.json")
         ) {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());
 
-            Attachment attachment = new Attachment();
+            attachment = new Attachment();
             attachment.setContentType("application/vnd.microsoft.card.adaptive");
             attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
             return attachment;

--- a/samples/java_springboot/15.handling-attachments/src/main/java/com/microsoft/bot/sample/attachments/AttachmentsBot.java
+++ b/samples/java_springboot/15.handling-attachments/src/main/java/com/microsoft/bot/sample/attachments/AttachmentsBot.java
@@ -255,7 +255,12 @@ public class AttachmentsBot extends ActivityHandler {
     }
 
     private CompletableFuture<byte[]> getFileData(String filename) {
-        try (InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(filename)) {
+        Attachment adaptiveCardAttachment = new Attachment();
+
+        try (
+            InputStream inputStream = adaptiveCardAttachment.getClass()
+                .getClassLoader().getResourceAsStream(filename)
+        ) {
             return CompletableFuture.completedFuture(IOUtils.toByteArray(inputStream));
         } catch (Throwable t) {
             return Async.completeExceptionally(t);

--- a/samples/java_springboot/15.handling-attachments/src/main/java/com/microsoft/bot/sample/attachments/AttachmentsBot.java
+++ b/samples/java_springboot/15.handling-attachments/src/main/java/com/microsoft/bot/sample/attachments/AttachmentsBot.java
@@ -255,11 +255,9 @@ public class AttachmentsBot extends ActivityHandler {
     }
 
     private CompletableFuture<byte[]> getFileData(String filename) {
-        Attachment adaptiveCardAttachment = new Attachment();
-
         try (
-            InputStream inputStream = adaptiveCardAttachment.getClass()
-                .getClassLoader().getResourceAsStream(filename)
+            InputStream inputStream = getClass().getClassLoader()
+                .getResourceAsStream(filename)
         ) {
             return CompletableFuture.completedFuture(IOUtils.toByteArray(inputStream));
         } catch (Throwable t) {

--- a/samples/java_springboot/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/MultiLingualBot.java
+++ b/samples/java_springboot/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/MultiLingualBot.java
@@ -142,16 +142,16 @@ public class MultiLingualBot extends ActivityHandler {
      * @return the welcome adaptive card
      */
     private static Attachment createAdaptiveCardAttachment() {
-        Attachment adaptiveCardAttachment = new Attachment();
+        Attachment attachment = null;
 
         // combine path for cross platform support
         try (
-            InputStream inputStream = adaptiveCardAttachment.getClass().getClassLoader()
+            InputStream inputStream = attachment.getClass().getClassLoader()
                 .getResourceAsStream("cards/welcomeCard.json")
         ) {
             String adaptiveCardJson = IOUtils.toString(inputStream, StandardCharsets.UTF_8.toString());
 
-            Attachment attachment = new Attachment();
+            attachment = new Attachment();
             attachment.setContentType("application/vnd.microsoft.card.adaptive");
             attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
             return attachment;

--- a/samples/java_springboot/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/MultiLingualBot.java
+++ b/samples/java_springboot/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/MultiLingualBot.java
@@ -142,12 +142,14 @@ public class MultiLingualBot extends ActivityHandler {
      * @return the welcome adaptive card
      */
     private static Attachment createAdaptiveCardAttachment() {
+        Attachment adaptiveCardAttachment = new Attachment();
+
         // combine path for cross platform support
         try (
-            InputStream input = Thread.currentThread().getContextClassLoader()
+            InputStream inputStream = adaptiveCardAttachment.getClass().getClassLoader()
                 .getResourceAsStream("cards/welcomeCard.json")
         ) {
-            String adaptiveCardJson = IOUtils.toString(input, StandardCharsets.UTF_8.toString());
+            String adaptiveCardJson = IOUtils.toString(inputStream, StandardCharsets.UTF_8.toString());
 
             Attachment attachment = new Attachment();
             attachment.setContentType("application/vnd.microsoft.card.adaptive");

--- a/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/DialogAndWelcomeBot.java
+++ b/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/DialogAndWelcomeBot.java
@@ -78,9 +78,11 @@ public class DialogAndWelcomeBot<T extends Dialog> extends DialogBot {
 
     // Load attachment from embedded resource.
     private Attachment createAdaptiveCardAttachment() {
+        Attachment adaptiveCardAttachment = new Attachment();
+
         try (
-            InputStream inputStream = Thread.currentThread().
-                getContextClassLoader().getResourceAsStream("cards/welcomeCard.json")
+            InputStream inputStream = adaptiveCardAttachment.getClass().getClassLoader()
+                .getResourceAsStream("cards/welcomeCard.json")
         ) {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());

--- a/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/DialogAndWelcomeBot.java
+++ b/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/DialogAndWelcomeBot.java
@@ -78,16 +78,16 @@ public class DialogAndWelcomeBot<T extends Dialog> extends DialogBot {
 
     // Load attachment from embedded resource.
     private Attachment createAdaptiveCardAttachment() {
-        Attachment adaptiveCardAttachment = new Attachment();
+        Attachment attachment = null;
 
         try (
-            InputStream inputStream = adaptiveCardAttachment.getClass().getClassLoader()
+            InputStream inputStream = attachment.getClass().getClassLoader()
                 .getResourceAsStream("cards/welcomeCard.json")
         ) {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());
 
-            Attachment attachment = new Attachment();
+            attachment = new Attachment();
             attachment.setContentType("application/vnd.microsoft.card.adaptive");
             attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
             return attachment;

--- a/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/TeamsMessagingExtensionsSearchAuthConfigBot.java
+++ b/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/TeamsMessagingExtensionsSearchAuthConfigBot.java
@@ -433,15 +433,15 @@ public class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHa
     }
 
     private Attachment createAdaptiveCardAttachment() {
-        Attachment adaptiveCardAttachment = new Attachment();
+        Attachment attachment = null;
 
         try (
-            InputStream inputStream = adaptiveCardAttachment.getClass().getClassLoader()
+            InputStream inputStream = attachment.getClass().getClassLoader()
                 .getResourceAsStream("adaptiveCard.json")
         ) {
             String adaptiveCardJson = IOUtils.toString(inputStream, StandardCharsets.UTF_8.toString());
 
-            Attachment attachment = new Attachment();
+            attachment = new Attachment();
             attachment.setContentType("application/vnd.microsoft.card.adaptive");
             attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
             return attachment;

--- a/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/TeamsMessagingExtensionsSearchAuthConfigBot.java
+++ b/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/TeamsMessagingExtensionsSearchAuthConfigBot.java
@@ -433,11 +433,13 @@ public class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHa
     }
 
     private Attachment createAdaptiveCardAttachment() {
+        Attachment adaptiveCardAttachment = new Attachment();
+
         try (
-            InputStream input = Thread.currentThread().getContextClassLoader()
+            InputStream inputStream = adaptiveCardAttachment.getClass().getClassLoader()
                 .getResourceAsStream("adaptiveCard.json")
         ) {
-            String adaptiveCardJson = IOUtils.toString(input, StandardCharsets.UTF_8.toString());
+            String adaptiveCardJson = IOUtils.toString(inputStream, StandardCharsets.UTF_8.toString());
 
             Attachment attachment = new Attachment();
             attachment.setContentType("application/vnd.microsoft.card.adaptive");


### PR DESCRIPTION
We found out that there was an error while running Adaptive Cards sample locally with AD authentication enabled, this error was caused since the sample was using a `getContextClassLoader()` instead of a `getClassLoader()` as most of the samples did.

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - We implemented the changes to have consistency on all samples, using a classLoader in the following samples:
    - 07.using-adaptive-cards
    - 13.core-bot
    - 15.handling-attachments
    - 17.multilingual-bot
    - 21.corebot-app-insights
    - 52.teams-messaging-extensions-search-auth-config


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->