### PR TITLE
Enhanced the comment to include the expected outcome

### DIFF
--- a/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/TeamsMessagingExtensionsSearchAuthConfigBot.java
+++ b/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/TeamsMessagingExtensionsSearchAuthConfigBot.java
@@ -365,7 +365,10 @@ public class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHa
         TurnContext turnContext,
         MessagingExtensionAction action
     ) {
-        /* This can be uncommented once the MessagingExtensionAction contains the associated state property
+        /*
+        * For context, MessagingExtensionAction lacks the state property in the Java SDK
+        * Given that the SHOWPROFILE command requires this property to exist, this snippet was commented on purpose and should be uncommented once the MessagingExtensionAction is updated
+        * In the meantime, using the Compose action will trigger a 501 HTTP Status Code response as this snippet will not be executed
         if (action.getCommandId().equalsIgnoreCase("SHOWPROFILE")) {
             String state = action.getState(); // Check the state value
             return getTokenResponse(turnContext, state).thenCompose(tokenResponse -> {


### PR DESCRIPTION
## Description
Currently, the Teams App [manifest](https://github.com/southworks/BotBuilder-Samples/blob/e1b6d70b2be013bb5656f3652350c3c3bfc8b6bb/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/teamsAppManifest/manifest.json#L53-L71) and [README](https://github.com/southworks/BotBuilder-Samples/blob/main/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/README.md) describes the use of the `Compose` command, with triggers a `SHOWPROFILE` action. However, the snippet containing the logic to complete this action is commented due to a disparity with the .NET SDK and it's causing the action to fail with a 501 (Not implemented) HTTP Status Code:

![image](https://user-images.githubusercontent.com/58704965/126679815-033c10f6-1d27-4e7f-950b-a90203373d77.png)

![image](https://user-images.githubusercontent.com/58704965/126679838-a52e8cd8-e511-431c-808a-140360f7a6f9.png)

![image](https://user-images.githubusercontent.com/58704965/126679847-932a6b82-19a8-4c40-83ac-c1b00c48a48a.png)

Even though the snippet was commented, the comment did not give context about the reason behind. We updated the comment with the full context. 