### PR TITLE
Add QnAAuthKey property in application.properties of sample 49.qnamak…

### DIFF
--- a/samples/java_springboot/49.qnamaker-all-features/src/main/resources/application.properties
+++ b/samples/java_springboot/49.qnamaker-all-features/src/main/resources/application.properties
@@ -3,5 +3,6 @@ MicrosoftAppPassword=
 QnAKnowledgebaseId=
 QnAEndpointKey=
 QnAEndpointHostName=
+QnAAuthKey=
 DefaultAnswer=
 server.port=3978


### PR DESCRIPTION
…er-allfeatures

While validating the sample 49.qnamaker-allfeatures we noticed that the property QnAAuthKey was missing inside application.properties

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - Add missing properties inside application.properties
    - QnAAuthKey


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->