### PR TITLE
[Java][samples] Fix samples throwing an error when using local resources

### DIFF
--- a/samples/java_springboot/07.using-adaptive-cards/src/main/java/com/microsoft/bot/sample/usingadaptivecards/AdaptiveCardsBot.java
+++ b/samples/java_springboot/07.using-adaptive-cards/src/main/java/com/microsoft/bot/sample/usingadaptivecards/AdaptiveCardsBot.java
@@ -86,7 +86,7 @@ public class AdaptiveCardsBot extends ActivityHandler {
     }
 
     private static Attachment createAdaptiveCardAttachment(String filePath) {
-        Attachment attachment = null;
+        Attachment attachment = new Attachment();
 
         try (
             InputStream inputStream = attachment.getClass()
@@ -95,7 +95,6 @@ public class AdaptiveCardsBot extends ActivityHandler {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());
 
-            attachment = new Attachment();
             attachment.setContentType("application/vnd.microsoft.card.adaptive");
             attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
 

--- a/samples/java_springboot/13.core-bot/src/main/java/com/microsoft/bot/sample/core/DialogAndWelcomeBot.java
+++ b/samples/java_springboot/13.core-bot/src/main/java/com/microsoft/bot/sample/core/DialogAndWelcomeBot.java
@@ -78,7 +78,7 @@ public class DialogAndWelcomeBot<T extends Dialog> extends DialogBot {
 
     // Load attachment from embedded resource.
     private Attachment createAdaptiveCardAttachment() {
-        Attachment attachment = null;
+        Attachment attachment = new Attachment();
 
         try (
             InputStream inputStream = attachment.getClass()
@@ -87,7 +87,6 @@ public class DialogAndWelcomeBot<T extends Dialog> extends DialogBot {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());
 
-            attachment = new Attachment();
             attachment.setContentType("application/vnd.microsoft.card.adaptive");
             attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
             return attachment;

--- a/samples/java_springboot/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/MultiLingualBot.java
+++ b/samples/java_springboot/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/MultiLingualBot.java
@@ -142,7 +142,7 @@ public class MultiLingualBot extends ActivityHandler {
      * @return the welcome adaptive card
      */
     private static Attachment createAdaptiveCardAttachment() {
-        Attachment attachment = null;
+        Attachment attachment = new Attachment();
 
         // combine path for cross platform support
         try (
@@ -151,7 +151,6 @@ public class MultiLingualBot extends ActivityHandler {
         ) {
             String adaptiveCardJson = IOUtils.toString(inputStream, StandardCharsets.UTF_8.toString());
 
-            attachment = new Attachment();
             attachment.setContentType("application/vnd.microsoft.card.adaptive");
             attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
             return attachment;

--- a/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/DialogAndWelcomeBot.java
+++ b/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/DialogAndWelcomeBot.java
@@ -78,7 +78,7 @@ public class DialogAndWelcomeBot<T extends Dialog> extends DialogBot {
 
     // Load attachment from embedded resource.
     private Attachment createAdaptiveCardAttachment() {
-        Attachment attachment = null;
+        Attachment attachment = new Attachment();
 
         try (
             InputStream inputStream = attachment.getClass().getClassLoader()
@@ -87,7 +87,6 @@ public class DialogAndWelcomeBot<T extends Dialog> extends DialogBot {
             String adaptiveCardJson = IOUtils
                 .toString(inputStream, StandardCharsets.UTF_8.toString());
 
-            attachment = new Attachment();
             attachment.setContentType("application/vnd.microsoft.card.adaptive");
             attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
             return attachment;

--- a/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/TeamsMessagingExtensionsSearchAuthConfigBot.java
+++ b/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/TeamsMessagingExtensionsSearchAuthConfigBot.java
@@ -436,7 +436,7 @@ public class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHa
     }
 
     private Attachment createAdaptiveCardAttachment() {
-        Attachment attachment = null;
+        Attachment attachment = new Attachment();
 
         try (
             InputStream inputStream = attachment.getClass().getClassLoader()
@@ -444,7 +444,6 @@ public class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHa
         ) {
             String adaptiveCardJson = IOUtils.toString(inputStream, StandardCharsets.UTF_8.toString());
 
-            attachment = new Attachment();
             attachment.setContentType("application/vnd.microsoft.card.adaptive");
             attachment.setContent(Serialization.jsonToTree(adaptiveCardJson));
             return attachment;


### PR DESCRIPTION
Updated the attachment initialization to avoid null reference exception

## Proposed Changes
Samples updated:
- 07.using-adaptive-cards
- 13.core-bot
- 17.multilingual-bot
- 21.corebot-app-insights
- 52.teams-messaging-extensions-search-auth-config

## Testing
All samples were tested locally and sample #52 was also deployed to Azure