### PR TITLE
Modify all Java samples to use BotCloudAdapterController

### DIFF
--- a/samples/java_springboot/02.echo-bot/src/main/java/com/microsoft/bot/sample/echo/Application.java
+++ b/samples/java_springboot/02.echo-bot/src/main/java/com/microsoft/bot/sample/echo/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -19,12 +19,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/03.welcome-user/src/main/java/com/microsoft/bot/sample/welcomeuser/Application.java
+++ b/samples/java_springboot/03.welcome-user/src/main/java/com/microsoft/bot/sample/welcomeuser/Application.java
@@ -8,7 +8,7 @@ import com.microsoft.bot.builder.UserState;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -20,12 +20,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/05.multi-turn-prompt/src/main/java/com/microsoft/bot/sample/multiturnprompt/Application.java
+++ b/samples/java_springboot/05.multi-turn-prompt/src/main/java/com/microsoft/bot/sample/multiturnprompt/Application.java
@@ -10,7 +10,7 @@ import com.microsoft.bot.dialogs.Dialog;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -22,12 +22,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/06.using-cards/src/main/java/com/microsoft/bot/sample/usingcards/Application.java
+++ b/samples/java_springboot/06.using-cards/src/main/java/com/microsoft/bot/sample/usingcards/Application.java
@@ -10,7 +10,7 @@ import com.microsoft.bot.dialogs.Dialog;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -22,12 +22,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/07.using-adaptive-cards/src/main/java/com/microsoft/bot/sample/usingadaptivecards/Application.java
+++ b/samples/java_springboot/07.using-adaptive-cards/src/main/java/com/microsoft/bot/sample/usingadaptivecards/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 
 import org.springframework.boot.SpringApplication;
@@ -20,12 +20,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/08.suggested-actions/src/main/java/com/microsoft/bot/sample/suggestedactions/Application.java
+++ b/samples/java_springboot/08.suggested-actions/src/main/java/com/microsoft/bot/sample/suggestedactions/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -19,12 +19,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/11.qnamaker/src/main/java/com/microsoft/bot/sample/qnamaker/Application.java
+++ b/samples/java_springboot/11.qnamaker/src/main/java/com/microsoft/bot/sample/qnamaker/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -19,12 +19,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/13.core-bot/src/main/java/com/microsoft/bot/sample/core/Application.java
+++ b/samples/java_springboot/13.core-bot/src/main/java/com/microsoft/bot/sample/core/Application.java
@@ -9,7 +9,7 @@ import com.microsoft.bot.builder.UserState;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -21,12 +21,12 @@ import org.springframework.context.annotation.Import;
  */
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/14.nlp-with-dispatch/src/main/java/com/microsoft/bot/sample/nlpwithdispatch/Application.java
+++ b/samples/java_springboot/14.nlp-with-dispatch/src/main/java/com/microsoft/bot/sample/nlpwithdispatch/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 
 import org.springframework.boot.SpringApplication;
@@ -20,12 +20,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/15.handling-attachments/src/main/java/com/microsoft/bot/sample/attachments/Application.java
+++ b/samples/java_springboot/15.handling-attachments/src/main/java/com/microsoft/bot/sample/attachments/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -19,12 +19,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/16.proactive-messages/src/main/java/com/microsoft/bot/sample/proactive/Application.java
+++ b/samples/java_springboot/16.proactive-messages/src/main/java/com/microsoft/bot/sample/proactive/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -19,14 +19,14 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
 //
 // See NotifyController in this project for an example on adding a controller.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/Application.java
+++ b/samples/java_springboot/17.multilingual-bot/src/main/java/com/microsoft/bot/sample/multilingual/Application.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using

--- a/samples/java_springboot/18.bot-authentication/src/main/java/com/microsoft/bot/sample/authentication/Application.java
+++ b/samples/java_springboot/18.bot-authentication/src/main/java/com/microsoft/bot/sample/authentication/Application.java
@@ -10,7 +10,7 @@ import com.microsoft.bot.dialogs.Dialog;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -22,12 +22,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/19.custom-dialogs/src/main/java/com/microsoft/bot/sample/customdialogs/Application.java
+++ b/samples/java_springboot/19.custom-dialogs/src/main/java/com/microsoft/bot/sample/customdialogs/Application.java
@@ -10,7 +10,7 @@ import com.microsoft.bot.dialogs.Dialog;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -22,12 +22,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/Application.java
+++ b/samples/java_springboot/21.corebot-app-insights/src/main/java/com/microsoft/bot/sample/corebot/app/insights/Application.java
@@ -14,7 +14,7 @@ import com.microsoft.bot.builder.TelemetryLoggerMiddleware;
 import com.microsoft.bot.builder.UserState;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.SpringApplication;
@@ -27,12 +27,12 @@ import org.springframework.context.annotation.Import;
  */
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/23.facebook-events/src/main/java/com/microsoft/bot/sample/facebookevents/Application.java
+++ b/samples/java_springboot/23.facebook-events/src/main/java/com/microsoft/bot/sample/facebookevents/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 
 import org.springframework.boot.SpringApplication;
@@ -20,12 +20,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/24.bot-authentication-msgraph/src/main/java/com/microsoft/bot/sample/authentication/Application.java
+++ b/samples/java_springboot/24.bot-authentication-msgraph/src/main/java/com/microsoft/bot/sample/authentication/Application.java
@@ -9,7 +9,7 @@ import com.microsoft.bot.builder.UserState;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -21,12 +21,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/25.message-reaction/src/main/java/com/microsoft/bot/sample/messagereaction/Application.java
+++ b/samples/java_springboot/25.message-reaction/src/main/java/com/microsoft/bot/sample/messagereaction/Application.java
@@ -8,7 +8,7 @@ import com.microsoft.bot.builder.Storage;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -20,12 +20,12 @@ import org.springframework.context.annotation.Import;
  */
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/42.scaleout/src/main/java/com/microsoft/bot/sample/scaleout/Application.java
+++ b/samples/java_springboot/42.scaleout/src/main/java/com/microsoft/bot/sample/scaleout/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -19,12 +19,12 @@ import org.springframework.context.annotation.Import;
  */
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/43.complex-dialog/src/main/java/com/microsoft/bot/sample/complexdialog/Application.java
+++ b/samples/java_springboot/43.complex-dialog/src/main/java/com/microsoft/bot/sample/complexdialog/Application.java
@@ -10,7 +10,7 @@ import com.microsoft.bot.dialogs.Dialog;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -22,12 +22,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/44.prompt-users-for-input/src/main/java/com/microsoft/bot/sample/promptusersforinput/Application.java
+++ b/samples/java_springboot/44.prompt-users-for-input/src/main/java/com/microsoft/bot/sample/promptusersforinput/Application.java
@@ -9,7 +9,7 @@ import com.microsoft.bot.builder.UserState;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -21,12 +21,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/45.state-management/src/main/java/com/microsoft/bot/sample/statemanagement/Application.java
+++ b/samples/java_springboot/45.state-management/src/main/java/com/microsoft/bot/sample/statemanagement/Application.java
@@ -13,7 +13,7 @@ import com.microsoft.bot.builder.UserState;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -25,12 +25,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/46.teams-auth/src/main/java/com/microsoft/bot/sample/teamsauth/Application.java
+++ b/samples/java_springboot/46.teams-auth/src/main/java/com/microsoft/bot/sample/teamsauth/Application.java
@@ -10,7 +10,7 @@ import com.microsoft.bot.dialogs.Dialog;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -22,12 +22,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/47.inspection/src/main/java/com/microsoft/bot/sample/inspection/Application.java
+++ b/samples/java_springboot/47.inspection/src/main/java/com/microsoft/bot/sample/inspection/Application.java
@@ -24,7 +24,7 @@ import org.springframework.context.annotation.Primary;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using

--- a/samples/java_springboot/49.qnamaker-all-features/src/main/java/com/microsoft/bot/sample/qnamaker/all/features/Application.java
+++ b/samples/java_springboot/49.qnamaker-all-features/src/main/java/com/microsoft/bot/sample/qnamaker/all/features/Application.java
@@ -9,7 +9,7 @@ import com.microsoft.bot.builder.UserState;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -21,12 +21,12 @@ import org.springframework.context.annotation.Import;
  */
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/50.teams-messaging-extensions-search/src/main/java/com/microsoft/bot/sample/teamssearch/Application.java
+++ b/samples/java_springboot/50.teams-messaging-extensions-search/src/main/java/com/microsoft/bot/sample/teamssearch/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -19,12 +19,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/51.teams-messaging-extensions-action/src/main/java/com/microsoft/bot/sample/teamsaction/Application.java
+++ b/samples/java_springboot/51.teams-messaging-extensions-action/src/main/java/com/microsoft/bot/sample/teamsaction/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -19,12 +19,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/Application.java
+++ b/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/src/main/java/com/microsoft/bot/sample/teamssearchauth/Application.java
@@ -9,7 +9,7 @@ import com.microsoft.bot.builder.UserState;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -21,12 +21,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/53.teams-messaging-extensions-action-preview/src/main/java/com/microsoft/bot/sample/teamsactionpreview/Application.java
+++ b/samples/java_springboot/53.teams-messaging-extensions-action-preview/src/main/java/com/microsoft/bot/sample/teamsactionpreview/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -19,12 +19,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/54.teams-task-module/src/main/java/com/microsoft/bot/sample/teamstaskmodule/Application.java
+++ b/samples/java_springboot/54.teams-task-module/src/main/java/com/microsoft/bot/sample/teamstaskmodule/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -19,12 +19,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/55.teams-link-unfurling/src/main/java/com/microsoft/bot/sample/teamsunfurl/Application.java
+++ b/samples/java_springboot/55.teams-link-unfurling/src/main/java/com/microsoft/bot/sample/teamsunfurl/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -19,12 +19,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default

--- a/samples/java_springboot/56.teams-file-upload/src/main/java/com/microsoft/bot/sample/teamsfileupload/Application.java
+++ b/samples/java_springboot/56.teams-file-upload/src/main/java/com/microsoft/bot/sample/teamsfileupload/Application.java
@@ -7,7 +7,7 @@ import com.microsoft.bot.builder.Bot;
 import com.microsoft.bot.integration.CloudAdapterWithErrorHandler;
 import com.microsoft.bot.integration.CloudAdapter;
 import com.microsoft.bot.integration.Configuration;
-import com.microsoft.bot.integration.spring.BotController;
+import com.microsoft.bot.integration.spring.BotCloudAdapterController;
 import com.microsoft.bot.integration.spring.BotDependencyConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -19,12 +19,12 @@ import org.springframework.context.annotation.Import;
 //
 @SpringBootApplication
 
-// Use the default BotController to receive incoming Channel messages. A custom
+// Use the default BotCloudAdapterController to receive incoming Channel messages. A custom
 // controller could be used by eliminating this import and creating a new
 // org.springframework.web.bind.annotation.RestController.
 // The default controller is created by the Spring Boot container using
 // dependency injection. The default route is /api/messages.
-@Import({BotController.class})
+@Import({BotCloudAdapterController.class})
 
 /**
  * This class extends the BotDependencyConfiguration which provides the default


### PR DESCRIPTION
## Description
Modifies all Java samples to use the REST Controller using `CloudAdapter` instead of `BotController` that was using `BotFrameworkHttpAdapter`