### PR TITLE
Updated SDK version

### DIFF
--- a/samples/java_springboot/02.echo-bot/pom.xml
+++ b/samples/java_springboot/02.echo-bot/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/03.welcome-user/pom.xml
+++ b/samples/java_springboot/03.welcome-user/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/05.multi-turn-prompt/pom.xml
+++ b/samples/java_springboot/05.multi-turn-prompt/pom.xml
@@ -92,13 +92,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/06.using-cards/pom.xml
+++ b/samples/java_springboot/06.using-cards/pom.xml
@@ -92,13 +92,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/07.using-adaptive-cards/pom.xml
+++ b/samples/java_springboot/07.using-adaptive-cards/pom.xml
@@ -92,19 +92,19 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-builder</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>  </dependencies>
 

--- a/samples/java_springboot/08.suggested-actions/pom.xml
+++ b/samples/java_springboot/08.suggested-actions/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/11.qnamaker/pom.xml
+++ b/samples/java_springboot/11.qnamaker/pom.xml
@@ -77,7 +77,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-qna</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
@@ -98,7 +98,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/13.core-bot/pom.xml
+++ b/samples/java_springboot/13.core-bot/pom.xml
@@ -92,23 +92,23 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-luis-v3</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-applicationinsights</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
       </dependency>
   </dependencies>
 

--- a/samples/java_springboot/14.nlp-with-dispatch/pom.xml
+++ b/samples/java_springboot/14.nlp-with-dispatch/pom.xml
@@ -92,18 +92,18 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-luis-v3</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-qna</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
       </dependency>
     </dependencies>
 

--- a/samples/java_springboot/15.handling-attachments/pom.xml
+++ b/samples/java_springboot/15.handling-attachments/pom.xml
@@ -97,7 +97,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/16.proactive-messages/pom.xml
+++ b/samples/java_springboot/16.proactive-messages/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/17.multilingual-bot/pom.xml
+++ b/samples/java_springboot/17.multilingual-bot/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/18.bot-authentication/pom.xml
+++ b/samples/java_springboot/18.bot-authentication/pom.xml
@@ -92,13 +92,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/19.custom-dialogs/pom.xml
+++ b/samples/java_springboot/19.custom-dialogs/pom.xml
@@ -92,13 +92,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/21.corebot-app-insights/pom.xml
+++ b/samples/java_springboot/21.corebot-app-insights/pom.xml
@@ -92,23 +92,23 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-luis-v3</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-applicationinsights</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
       </dependency>
   </dependencies>
 

--- a/samples/java_springboot/23.facebook-events/pom.xml
+++ b/samples/java_springboot/23.facebook-events/pom.xml
@@ -91,13 +91,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/24.bot-authentication-msgraph/pom.xml
+++ b/samples/java_springboot/24.bot-authentication-msgraph/pom.xml
@@ -97,13 +97,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/25.message-reaction/pom.xml
+++ b/samples/java_springboot/25.message-reaction/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/40.timex-resolution/pom.xml
+++ b/samples/java_springboot/40.timex-resolution/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.microsoft.bot</groupId>
       <artifactId>bot-dialogs</artifactId>
-      <version>4.13.0</version>
+      <version>4.15.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/samples/java_springboot/42.scaleout/pom.xml
+++ b/samples/java_springboot/42.scaleout/pom.xml
@@ -81,13 +81,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/samples/java_springboot/43.complex-dialog/pom.xml
+++ b/samples/java_springboot/43.complex-dialog/pom.xml
@@ -92,13 +92,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/44.prompt-users-for-input/pom.xml
+++ b/samples/java_springboot/44.prompt-users-for-input/pom.xml
@@ -92,13 +92,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/45.state-management/pom.xml
+++ b/samples/java_springboot/45.state-management/pom.xml
@@ -91,13 +91,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-azure</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/46.teams-auth/pom.xml
+++ b/samples/java_springboot/46.teams-auth/pom.xml
@@ -98,13 +98,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/47.inspection/pom.xml
+++ b/samples/java_springboot/47.inspection/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/49.qnamaker-all-features/pom.xml
+++ b/samples/java_springboot/49.qnamaker-all-features/pom.xml
@@ -77,7 +77,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-qna</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
@@ -98,7 +98,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/50.teams-messaging-extensions-search/pom.xml
+++ b/samples/java_springboot/50.teams-messaging-extensions-search/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/samples/java_springboot/51.teams-messaging-extensions-action/pom.xml
+++ b/samples/java_springboot/51.teams-messaging-extensions-action/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/pom.xml
+++ b/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/pom.xml
@@ -97,7 +97,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
     </dependencies>

--- a/samples/java_springboot/53.teams-messaging-extensions-action-preview/pom.xml
+++ b/samples/java_springboot/53.teams-messaging-extensions-action-preview/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/54.teams-task-module/pom.xml
+++ b/samples/java_springboot/54.teams-task-module/pom.xml
@@ -91,7 +91,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/samples/java_springboot/55.teams-link-unfurling/pom.xml
+++ b/samples/java_springboot/55.teams-link-unfurling/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/56.teams-file-upload/pom.xml
+++ b/samples/java_springboot/56.teams-file-upload/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/57.teams-conversation-bot/pom.xml
+++ b/samples/java_springboot/57.teams-conversation-bot/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/58.teams-start-new-thread-in-channel/pom.xml
+++ b/samples/java_springboot/58.teams-start-new-thread-in-channel/pom.xml
@@ -91,7 +91,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/samples/java_springboot/80.skills-simple-bot-to-bot/DialogRootBot/pom.xml
+++ b/samples/java_springboot/80.skills-simple-bot-to-bot/DialogRootBot/pom.xml
@@ -92,13 +92,13 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-builder</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/80.skills-simple-bot-to-bot/DialogRootBot/src/main/java/com/microsoft/bot/sample/simplerootbot/Application.java
+++ b/samples/java_springboot/80.skills-simple-bot-to-bot/DialogRootBot/src/main/java/com/microsoft/bot/sample/simplerootbot/Application.java
@@ -115,7 +115,7 @@ public class Application extends BotDependencyConfiguration {
     }
 
     @Bean public ChannelServiceHandler getChannelServiceHandler(
-        BotAdapter botAdapter,
+        BotFrameworkHttpAdapter botAdapter,
         Bot bot,
         SkillConversationIdFactoryBase conversationIdFactory,
         CredentialProvider credentialProvider,

--- a/samples/java_springboot/80.skills-simple-bot-to-bot/DialogSkillBot/pom.xml
+++ b/samples/java_springboot/80.skills-simple-bot-to-bot/DialogSkillBot/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/samples/java_springboot/81.skills-skilldialog/dialog-root-bot/pom.xml
+++ b/samples/java_springboot/81.skills-skilldialog/dialog-root-bot/pom.xml
@@ -92,19 +92,19 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-builder</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>  </dependencies>
 

--- a/samples/java_springboot/81.skills-skilldialog/dialog-skill-bot/pom.xml
+++ b/samples/java_springboot/81.skills-skilldialog/dialog-skill-bot/pom.xml
@@ -92,19 +92,19 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-spring</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-dialogs</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-ai-luis-v3</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
       </dependency>
     </dependencies>
   <profiles>

--- a/samples/java_springboot/81.skills-skilldialog/dialog-skill-bot/pom.xml
+++ b/samples/java_springboot/81.skills-skilldialog/dialog-skill-bot/pom.xml
@@ -106,6 +106,11 @@
         <artifactId>bot-ai-luis-v3</artifactId>
         <version>4.15.0-SNAPSHOT</version>
       </dependency>
+      <dependency>
+        <groupId>com.microsoft.bot</groupId>
+        <artifactId>bot-applicationinsights</artifactId>
+        <version>4.15.0-SNAPSHOT</version>
+      </dependency>
     </dependencies>
   <profiles>
     <profile>

--- a/samples/java_springboot/pom.xml
+++ b/samples/java_springboot/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.microsoft.bot</groupId>
   <artifactId>bot-java</artifactId>
-  <version>4.13.0</version>
+  <version>4.15.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Microsoft BotBuilder Java SDK Parent</name>

--- a/samples/java_springboot/servlet-echo/pom.xml
+++ b/samples/java_springboot/servlet-echo/pom.xml
@@ -98,7 +98,7 @@
       <dependency>
         <groupId>com.microsoft.bot</groupId>
         <artifactId>bot-integration-core</artifactId>
-        <version>4.13.0</version>
+        <version>4.15.0-SNAPSHOT</version>
       </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Description
Updates SDK version for Java Samples

## Specific Changes
- Modify the dependency on the SDK to `4.15.0-SNAPSHOT`
- Modify the sample 80 to define the expected adapter type instead of using the generic class
- Modified the sample 81 to add a missing dependency 