### PR TITLE
[#3340] Deployment ARM templates update (template-with-new-rg) - samples/csharp_dotnetcore

### DIFF
--- a/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/template-with-new-rg.json
@@ -170,7 +170,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/template-with-new-rg.json
@@ -153,24 +153,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/03.welcome-user/deploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/03.welcome-user/deploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/03.welcome-user/deploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/03.welcome-user/deploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/06.using-cards/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/06.using-cards/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/06.using-cards/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/06.using-cards/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/08.suggested-actions/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/08.suggested-actions/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/08.suggested-actions/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/08.suggested-actions/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/template-with-new-rg.json
@@ -170,7 +170,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/template-with-new-rg.json
@@ -153,24 +153,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/16.proactive-messages/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/16.proactive-messages/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/16.proactive-messages/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/16.proactive-messages/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/17.multilingual-bot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/17.multilingual-bot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/19.custom-dialogs/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/19.custom-dialogs/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/DeploymentTemplates/template-with-new-rg.json
@@ -170,7 +170,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/DeploymentTemplates/template-with-new-rg.json
@@ -153,24 +153,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/23.facebook-events/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/23.facebook-events/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/23.facebook-events/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/23.facebook-events/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/25.message-reaction/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/25.message-reaction/DeploymentTemplates/template-with-new-rg.json
@@ -152,42 +152,43 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/csharp_dotnetcore/25.message-reaction/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/25.message-reaction/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/47.inspection/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/47.inspection/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/47.inspection/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/47.inspection/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/55.teams-link-unfurling/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/55.teams-link-unfurling/DeploymentTemplates/template-with-new-rg.json
@@ -152,42 +152,44 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/DeploymentTemplates/template-with-new-rg.json
@@ -152,42 +152,44 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/DeploymentTemplates/template-with-new-rg.json
@@ -152,42 +152,44 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/csharp_dotnetcore/60.slack-adapter/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/60.slack-adapter/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/60.slack-adapter/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/60.slack-adapter/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/61.facebook-adapter/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/61.facebook-adapter/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/61.facebook-adapter/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/61.facebook-adapter/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/62.webex-adapter/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/62.webex-adapter/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/62.webex-adapter/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/62.webex-adapter/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/63.twilio-adapter/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/63.twilio-adapter/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/63.twilio-adapter/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/63.twilio-adapter/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json
@@ -170,7 +170,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/template-with-new-rg.json
@@ -153,24 +153,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/template-with-new-rg.json
@@ -170,7 +170,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/template-with-new-rg.json
@@ -153,24 +153,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DeploymentTemplates/template-with-new-rg.json
@@ -170,7 +170,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DeploymentTemplates/template-with-new-rg.json
@@ -153,24 +153,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DeploymentTemplates/template-with-new-rg.json
@@ -170,7 +170,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DeploymentTemplates/template-with-new-rg.json
@@ -153,24 +153,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/Dialogs/ComposerDialogs/main-without-luis/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/Dialogs/ComposerDialogs/main-without-luis/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/Dialogs/ComposerDialogs/main-without-luis/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/Dialogs/ComposerDialogs/main-without-luis/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/language-generation/05.multi-turn-prompt/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/05.multi-turn-prompt/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/language-generation/05.multi-turn-prompt/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/05.multi-turn-prompt/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/language-generation/06.using-cards/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/06.using-cards/DeploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/language-generation/06.using-cards/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/06.using-cards/DeploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/language-generation/13.core-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/13.core-bot/deploymentTemplates/template-with-new-rg.json
@@ -152,24 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/language-generation/13.core-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/13.core-bot/deploymentTemplates/template-with-new-rg.json
@@ -169,7 +169,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/language-generation/20.extending-with-custom-functions/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/20.extending-with-custom-functions/DeploymentTemplates/template-with-new-rg.json
@@ -170,7 +170,8 @@
                                 "luisAppIds": [],
                                 "schemaTransformationVersion": "1.3",
                                 "isCmekEnabled": false,
-                                "isIsolated": false                            },
+                                "isIsolated": false
+                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]

--- a/samples/csharp_dotnetcore/language-generation/20.extending-with-custom-functions/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/20.extending-with-custom-functions/DeploymentTemplates/template-with-new-rg.json
@@ -153,24 +153,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false                            },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]


### PR DESCRIPTION
Addresses # 3340

## Proposed Changes
This PR updates the deployment templates (`template-with-new-rg.json`) of the bots inside [samples/csharp_dotnetcore](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/csharp_dotnetcore) folder to use the new Azure resource `Azure Bot` instead of the Bot Channel Registration.

### Detailed Changes
Updated the ARM templates of the following samples:
- 02.echo-bot
- 03.welcome-user
- 05.multi-turn-prompt
- 06.using-cards
- 07.using-adaptive-cards
- 08.suggested-actions
- 11.qnamaker
- 13.core-bot
- 15.handling-attachments
- 16.proactive-messages
- 17.multilingual-bot
- 18.bot-authentication
- 19.custom-dialogs
- 21.corebot-app-insights
- 23.facebook-events
- 24.bot-authentication-msgraph
- 25.message-reaction
- 46.teams-auth
- 47.inspection
- 49.qnamaker-all-features
- 55.teams-link-unfurling
- 57.teams-conversation-bot
- 58.teams-start-new-thread-in-channel
- 60.slack-adapter
- 61.facebook-adapter
- 62.webex-adapter
- 63.twilio-adapter
- 80.skills-simple-bot-to-bot/EchoSkillBot
- 80.skills-simple-bot-to-bot/SimpleRootBot
- 81.skills-skilldialog/DialogRootBot
- 81.skills-skilldialog/DialogSkillBot
- adaptive-dialog/09.integrating-composer-dialogs
- language-generation/05.a.multi-turn-prompt-with-language-fallback
- language-generation/05.multi-turn-prompt
- language-generation/06.using-cards
- language-generation/13.core-bot
- 20.extending-with-custom-functions 

## Testing
The following images show two bot samples working on azure, the first being the `55.teams-link-unfurling` and the second the `02.echo-bot`.
![image](https://user-images.githubusercontent.com/62260472/130132414-a430f44d-0a11-4c1b-bb39-43a68e692e31.png)
