### PR TITLE
[#3340] Deployment ARM templates update (template-with-preexisting-rg) - samples/javascript_nodejs

### DIFF
--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "botName": {
-            "type": "string",            
+            "type": "string",
             "minLength": 2
         },
         "sku": {
@@ -38,7 +38,7 @@
     },
     "variables": {
         "siteHost": "[concat(parameters('botName'), '.azurewebsites.net')]",
-		"botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
     },
     "resources": [
         {
@@ -51,7 +51,7 @@
             "properties": {
                 "name": "[parameters('botName')]",
                 "reserved": true,
-                "perSiteScaling": false,                
+                "perSiteScaling": false,
                 "targetWorkerCount": 0,
                 "targetWorkerSizeId": 0
             }
@@ -105,7 +105,7 @@
                 "containerSize": 0,
                 "dailyMemoryTimeQuota": 0,
                 "httpsOnly": false
-            }        
+            }
         },
         {
             "type": "Microsoft.Web/sites/config",
@@ -197,29 +197,30 @@
                 "reservedInstanceCount": 0
             }
         },
-		{
-			"apiVersion": "2017-12-01",
-			"type": "Microsoft.BotService/botServices",
-			"name": "[parameters('botName')]",
-			"location": "global",
-			"kind": "bot",
-			"sku": {
-				"name": "[parameters('botName')]"
-			},
-			"properties": {
-				"name": "[parameters('botName')]",
-				"displayName": "[parameters('botName')]",
-				"endpoint": "[variables('botEndpoint')]",
-				"msaAppId": "[parameters('appId')]",
-				"developerAppInsightsApplicationId": null,
-				"developerAppInsightKey": null,
-				"publishingCredentials": null,
-				"storageResourceId": null
-			},
-			"dependsOn": [
-				"[resourceId('Microsoft.Web/sites/', parameters('botName'))]"
-			]
-		},
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botName')]",
+            "location": "global",
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botName')]"
+            },
+            "properties": {
+                "name": "[parameters('botName')]",
+                "displayName": "[parameters('botName')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', parameters('botName'))]"
+            ]
+        },
         {
             "type": "Microsoft.Web/sites/hostNameBindings",
             "apiVersion": "2016-08-01",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/11.qnamaker/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/11.qnamaker/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "botName": {
-            "type": "string",            
+            "type": "string",
             "minLength": 2
         },
         "sku": {
@@ -38,7 +38,7 @@
     },
     "variables": {
         "siteHost": "[concat(parameters('botName'), '.azurewebsites.net')]",
-		"botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
     },
     "resources": [
         {
@@ -51,7 +51,7 @@
             "properties": {
                 "name": "[parameters('botName')]",
                 "reserved": true,
-                "perSiteScaling": false,                
+                "perSiteScaling": false,
                 "targetWorkerCount": 0,
                 "targetWorkerSizeId": 0
             }
@@ -105,7 +105,7 @@
                 "containerSize": 0,
                 "dailyMemoryTimeQuota": 0,
                 "httpsOnly": false
-            }        
+            }
         },
         {
             "type": "Microsoft.Web/sites/config",
@@ -197,29 +197,30 @@
                 "reservedInstanceCount": 0
             }
         },
-		{
-			"apiVersion": "2017-12-01",
-			"type": "Microsoft.BotService/botServices",
-			"name": "[parameters('botName')]",
-			"location": "global",
-			"kind": "bot",
-			"sku": {
-				"name": "[parameters('botName')]"
-			},
-			"properties": {
-				"name": "[parameters('botName')]",
-				"displayName": "[parameters('botName')]",
-				"endpoint": "[variables('botEndpoint')]",
-				"msaAppId": "[parameters('appId')]",
-				"developerAppInsightsApplicationId": null,
-				"developerAppInsightKey": null,
-				"publishingCredentials": null,
-				"storageResourceId": null
-			},
-			"dependsOn": [
-				"[resourceId('Microsoft.Web/sites/', parameters('botName'))]"
-			]
-		},
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botName')]",
+            "location": "global",
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botName')]"
+            },
+            "properties": {
+                "name": "[parameters('botName')]",
+                "displayName": "[parameters('botName')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', parameters('botName'))]"
+            ]
+        },
         {
             "type": "Microsoft.Web/sites/hostNameBindings",
             "apiVersion": "2016-08-01",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/25.message-reaction/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/25.message-reaction/deploymentTemplates/template-with-preexisting-rg.json
@@ -127,41 +127,45 @@
                 }
             }
         },
-      {
-        "apiVersion": "2017-12-01",
-        "type": "Microsoft.BotService/botServices",
-        "name": "[parameters('botId')]",
-        "location": "global",
-        "kind": "bot",
-        "sku": {
-          "name": "[parameters('botSku')]"
-        },
-        "properties": {
-          "name": "[parameters('botId')]",
-          "displayName": "[parameters('botId')]",
-          "endpoint": "[variables('botEndpoint')]",
-          "msaAppId": "[parameters('appId')]",
-          "developerAppInsightsApplicationId": null,
-          "developerAppInsightKey": null,
-          "publishingCredentials": null,
-          "storageResourceId": null
-        },
-        "resources": [
-          {
-            "name": "MsTeamsChannel",
-            "type": "channels",
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
             "location": "global",
-            "apiVersion": "2018-07-12",
-            "kind": "bot",
-            "properties": {
-              "channelName": "MsTeamsChannel"
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botSku')]"
             },
-            "dependsOn": [ "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]" ]
-          }
-        ],
-        "dependsOn": [
-          "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-        ]
-      }
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
+        }
     ]
 }

--- a/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/49.qnamaker-all-features/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/template-with-preexisting-rg.json
@@ -127,41 +127,45 @@
                 }
             }
         },
-      {
-        "apiVersion": "2017-12-01",
-        "type": "Microsoft.BotService/botServices",
-        "name": "[parameters('botId')]",
-        "location": "global",
-        "kind": "bot",
-        "sku": {
-          "name": "[parameters('botSku')]"
-        },
-        "properties": {
-          "name": "[parameters('botId')]",
-          "displayName": "[parameters('botId')]",
-          "endpoint": "[variables('botEndpoint')]",
-          "msaAppId": "[parameters('appId')]",
-          "developerAppInsightsApplicationId": null,
-          "developerAppInsightKey": null,
-          "publishingCredentials": null,
-          "storageResourceId": null
-        },
-        "resources": [
-          {
-            "name": "MsTeamsChannel",
-            "type": "channels",
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
             "location": "global",
-            "apiVersion": "2018-07-12",
-            "kind": "bot",
-            "properties": {
-              "channelName": "MsTeamsChannel"
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botSku')]"
             },
-            "dependsOn": [ "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]" ]
-          }
-        ],
-        "dependsOn": [
-          "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-        ]
-      }
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
+        }
     ]
 }

--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/template-with-preexisting-rg.json
@@ -127,41 +127,45 @@
                 }
             }
         },
-      {
-        "apiVersion": "2017-12-01",
-        "type": "Microsoft.BotService/botServices",
-        "name": "[parameters('botId')]",
-        "location": "global",
-        "kind": "bot",
-        "sku": {
-          "name": "[parameters('botSku')]"
-        },
-        "properties": {
-          "name": "[parameters('botId')]",
-          "displayName": "[parameters('botId')]",
-          "endpoint": "[variables('botEndpoint')]",
-          "msaAppId": "[parameters('appId')]",
-          "developerAppInsightsApplicationId": null,
-          "developerAppInsightKey": null,
-          "publishingCredentials": null,
-          "storageResourceId": null
-        },
-        "resources": [
-          {
-            "name": "MsTeamsChannel",
-            "type": "channels",
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
             "location": "global",
-            "apiVersion": "2018-07-12",
-            "kind": "bot",
-            "properties": {
-              "channelName": "MsTeamsChannel"
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botSku')]"
             },
-            "dependsOn": [ "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]" ]
-          }
-        ],
-        "dependsOn": [
-          "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-        ]
-      }
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
+        }
     ]
 }

--- a/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-preexisting-rg.json
@@ -127,41 +127,45 @@
                 }
             }
         },
-      {
-        "apiVersion": "2017-12-01",
-        "type": "Microsoft.BotService/botServices",
-        "name": "[parameters('botId')]",
-        "location": "global",
-        "kind": "bot",
-        "sku": {
-          "name": "[parameters('botSku')]"
-        },
-        "properties": {
-          "name": "[parameters('botId')]",
-          "displayName": "[parameters('botId')]",
-          "endpoint": "[variables('botEndpoint')]",
-          "msaAppId": "[parameters('appId')]",
-          "developerAppInsightsApplicationId": null,
-          "developerAppInsightKey": null,
-          "publishingCredentials": null,
-          "storageResourceId": null
-        },
-        "resources": [
-          {
-            "name": "MsTeamsChannel",
-            "type": "channels",
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
             "location": "global",
-            "apiVersion": "2018-07-12",
-            "kind": "bot",
-            "properties": {
-              "channelName": "MsTeamsChannel"
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botSku')]"
             },
-            "dependsOn": [ "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]" ]
-          }
-        ],
-        "dependsOn": [
-          "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-        ]
-      }
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
+        }
     ]
 }

--- a/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-preexisting-rg.json
@@ -127,41 +127,45 @@
                 }
             }
         },
-      {
-        "apiVersion": "2017-12-01",
-        "type": "Microsoft.BotService/botServices",
-        "name": "[parameters('botId')]",
-        "location": "global",
-        "kind": "bot",
-        "sku": {
-          "name": "[parameters('botSku')]"
-        },
-        "properties": {
-          "name": "[parameters('botId')]",
-          "displayName": "[parameters('botId')]",
-          "endpoint": "[variables('botEndpoint')]",
-          "msaAppId": "[parameters('appId')]",
-          "developerAppInsightsApplicationId": null,
-          "developerAppInsightKey": null,
-          "publishingCredentials": null,
-          "storageResourceId": null
-        },
-        "resources": [
-          {
-            "name": "MsTeamsChannel",
-            "type": "channels",
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
             "location": "global",
-            "apiVersion": "2018-07-12",
-            "kind": "bot",
-            "properties": {
-              "channelName": "MsTeamsChannel"
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botSku')]"
             },
-            "dependsOn": [ "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]" ]
-          }
-        ],
-        "dependsOn": [
-          "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-        ]
-      }
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
+        }
     ]
 }

--- a/samples/javascript_nodejs/54.teams-task-module/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/54.teams-task-module/deploymentTemplates/template-with-preexisting-rg.json
@@ -127,41 +127,45 @@
                 }
             }
         },
-      {
-        "apiVersion": "2017-12-01",
-        "type": "Microsoft.BotService/botServices",
-        "name": "[parameters('botId')]",
-        "location": "global",
-        "kind": "bot",
-        "sku": {
-          "name": "[parameters('botSku')]"
-        },
-        "properties": {
-          "name": "[parameters('botId')]",
-          "displayName": "[parameters('botId')]",
-          "endpoint": "[variables('botEndpoint')]",
-          "msaAppId": "[parameters('appId')]",
-          "developerAppInsightsApplicationId": null,
-          "developerAppInsightKey": null,
-          "publishingCredentials": null,
-          "storageResourceId": null
-        },
-        "resources": [
-          {
-            "name": "MsTeamsChannel",
-            "type": "channels",
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
             "location": "global",
-            "apiVersion": "2018-07-12",
-            "kind": "bot",
-            "properties": {
-              "channelName": "MsTeamsChannel"
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botSku')]"
             },
-            "dependsOn": [ "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]" ]
-          }
-        ],
-        "dependsOn": [
-          "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-        ]
-      }
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
+        }
     ]
 }

--- a/samples/javascript_nodejs/55.teams-link-unfurling/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/55.teams-link-unfurling/deploymentTemplates/template-with-preexisting-rg.json
@@ -127,41 +127,45 @@
                 }
             }
         },
-      {
-        "apiVersion": "2017-12-01",
-        "type": "Microsoft.BotService/botServices",
-        "name": "[parameters('botId')]",
-        "location": "global",
-        "kind": "bot",
-        "sku": {
-          "name": "[parameters('botSku')]"
-        },
-        "properties": {
-          "name": "[parameters('botId')]",
-          "displayName": "[parameters('botId')]",
-          "endpoint": "[variables('botEndpoint')]",
-          "msaAppId": "[parameters('appId')]",
-          "developerAppInsightsApplicationId": null,
-          "developerAppInsightKey": null,
-          "publishingCredentials": null,
-          "storageResourceId": null
-        },
-        "resources": [
-          {
-            "name": "MsTeamsChannel",
-            "type": "channels",
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
             "location": "global",
-            "apiVersion": "2018-07-12",
-            "kind": "bot",
-            "properties": {
-              "channelName": "MsTeamsChannel"
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botSku')]"
             },
-            "dependsOn": [ "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]" ]
-          }
-        ],
-        "dependsOn": [
-          "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-        ]
-      }
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
+        }
     ]
 }

--- a/samples/javascript_nodejs/56.teams-file-upload/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/56.teams-file-upload/deploymentTemplates/template-with-preexisting-rg.json
@@ -127,41 +127,45 @@
                 }
             }
         },
-      {
-        "apiVersion": "2017-12-01",
-        "type": "Microsoft.BotService/botServices",
-        "name": "[parameters('botId')]",
-        "location": "global",
-        "kind": "bot",
-        "sku": {
-          "name": "[parameters('botSku')]"
-        },
-        "properties": {
-          "name": "[parameters('botId')]",
-          "displayName": "[parameters('botId')]",
-          "endpoint": "[variables('botEndpoint')]",
-          "msaAppId": "[parameters('appId')]",
-          "developerAppInsightsApplicationId": null,
-          "developerAppInsightKey": null,
-          "publishingCredentials": null,
-          "storageResourceId": null
-        },
-        "resources": [
-          {
-            "name": "MsTeamsChannel",
-            "type": "channels",
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
             "location": "global",
-            "apiVersion": "2018-07-12",
-            "kind": "bot",
-            "properties": {
-              "channelName": "MsTeamsChannel"
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botSku')]"
             },
-            "dependsOn": [ "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]" ]
-          }
-        ],
-        "dependsOn": [
-          "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-        ]
-      }
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
+        }
     ]
 }

--- a/samples/javascript_nodejs/57.teams-conversation-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -127,41 +127,45 @@
                 }
             }
         },
-      {
-        "apiVersion": "2017-12-01",
-        "type": "Microsoft.BotService/botServices",
-        "name": "[parameters('botId')]",
-        "location": "global",
-        "kind": "bot",
-        "sku": {
-          "name": "[parameters('botSku')]"
-        },
-        "properties": {
-          "name": "[parameters('botId')]",
-          "displayName": "[parameters('botId')]",
-          "endpoint": "[variables('botEndpoint')]",
-          "msaAppId": "[parameters('appId')]",
-          "developerAppInsightsApplicationId": null,
-          "developerAppInsightKey": null,
-          "publishingCredentials": null,
-          "storageResourceId": null
-        },
-        "resources": [
-          {
-            "name": "MsTeamsChannel",
-            "type": "channels",
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
             "location": "global",
-            "apiVersion": "2018-07-12",
-            "kind": "bot",
-            "properties": {
-              "channelName": "MsTeamsChannel"
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botSku')]"
             },
-            "dependsOn": [ "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]" ]
-          }
-        ],
-        "dependsOn": [
-          "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-        ]
-      }
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
+        }
     ]
 }

--- a/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-preexisting-rg.json
@@ -127,41 +127,45 @@
                 }
             }
         },
-      {
-        "apiVersion": "2017-12-01",
-        "type": "Microsoft.BotService/botServices",
-        "name": "[parameters('botId')]",
-        "location": "global",
-        "kind": "bot",
-        "sku": {
-          "name": "[parameters('botSku')]"
-        },
-        "properties": {
-          "name": "[parameters('botId')]",
-          "displayName": "[parameters('botId')]",
-          "endpoint": "[variables('botEndpoint')]",
-          "msaAppId": "[parameters('appId')]",
-          "developerAppInsightsApplicationId": null,
-          "developerAppInsightKey": null,
-          "publishingCredentials": null,
-          "storageResourceId": null
-        },
-        "resources": [
-          {
-            "name": "MsTeamsChannel",
-            "type": "channels",
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
             "location": "global",
-            "apiVersion": "2018-07-12",
-            "kind": "bot",
-            "properties": {
-              "channelName": "MsTeamsChannel"
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botSku')]"
             },
-            "dependsOn": [ "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]" ]
-          }
-        ],
-        "dependsOn": [
-          "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-        ]
-      }
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
+        }
     ]
 }

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/language-generation/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/language-generation/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/language-generation/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/javascript_nodejs/language-generation/20.custom-functions/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/language-generation/20.custom-functions/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"


### PR DESCRIPTION
Addresses # 3340

## Proposed Changes
This PR updates the deployment templates (`template-with-preexisting-rg.json`) of the bots inside [samples/javascript_nodejs](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/javascript_nodejs) folder to use the new Azure resource `Azure Bot` instead of the Bot Channel Registration.

### Detailed Changes
Updated the ARM templates of the following samples:
- 02.echo-bot
- 03.welcome-user
- 05.multi-turn-prompt
- 06.using-cards
- 07.using-adaptive-cards
- 08.suggested-actions
- 11.qnamaker
- 13.core-bot
- 15.handling-attachments
- 16.proactive-messages
- 17.multilingual-bot
- 18.bot-authentication
- 19.custom-dialogs
- 21.corebot-app-insights
- 24.bot-authentication-msgraph
- 25.message-reaction
- 46.teams-auth
- 47.inspection
- 49.qnamaker-all-features
- 50.teams-messaging-extensions-search
- 51.teams-messaging-extensions-action
- 52.teams-messaging-extensions-search-auth-config
- 53.teams-messaging-extensions-action-preview
- 54.teams-task-module
- 55.teams-link-unfurling
- 56.teams-file-upload
- 57.teams-conversation-bot
- 58.teams-start-new-thread-in-channel
- 80.skills-simple-bot-to-bot/echo-skill-bot
- 80.skills-simple-bot-to-bot/simple-root-bot
- 81.skills-skilldialog/dialogRootBot
- 81.skills-skilldialog/dialogSkillBot
- language-generation/06.using-cards
- language-generation/13.core-bot
- language-generation/20.custom-functions 

## Testing
These images show some of the javascript_nodejs samples deployed in Azure and working as expected.
![image](https://user-images.githubusercontent.com/44245136/130254751-5c610a2b-ac39-4c7b-8315-22bded7970ab.png)
