### PR TITLE
[#3340] Deployment ARM templates update (template-with-preexisting-rg) - samples/java_springboot

### DIFF
--- a/samples/java_springboot/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/03.welcome-user/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/03.welcome-user/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/05.multi-turn-prompt/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/05.multi-turn-prompt/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/07.using-adaptive-cards/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/07.using-adaptive-cards/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/08.suggested-actions/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/08.suggested-actions/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/11.qnamaker/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/11.qnamaker/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/14.nlp-with-dispatch/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/14.nlp-with-dispatch/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/15.handling-attachments/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/15.handling-attachments/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/16.proactive-messages/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/16.proactive-messages/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/17.multilingual-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/17.multilingual-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/18.bot-authentication/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/18.bot-authentication/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/19.custom-dialogs/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/19.custom-dialogs/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/21.corebot-app-insights/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/21.corebot-app-insights/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/23.facebook-events/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/23.facebook-events/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/24.bot-authentication-msgraph/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/24.bot-authentication-msgraph/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/25.message-reaction/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/25.message-reaction/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/43.complex-dialog/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/43.complex-dialog/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/44.prompt-users-for-input/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/44.prompt-users-for-input/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/45.state-management/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/45.state-management/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/47.inspection/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/47.inspection/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/49.qnamaker-all-features/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/49.qnamaker-all-features/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/50.teams-messaging-extensions-search/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/50.teams-messaging-extensions-search/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/51.teams-messaging-extensions-action/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/51.teams-messaging-extensions-action/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/54.teams-task-module/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/54.teams-task-module/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/55.teams-link-unfurling/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/55.teams-link-unfurling/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/56.teams-file-upload/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/56.teams-file-upload/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/57.teams-conversation-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/57.teams-conversation-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/80.skills-simple-bot-to-bot/DialogRootBot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/80.skills-simple-bot-to-bot/DialogRootBot/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/80.skills-simple-bot-to-bot/DialogSkillBot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/80.skills-simple-bot-to-bot/DialogSkillBot/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/81.skills-skilldialog/dialog-root-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/81.skills-skilldialog/dialog-root-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/81.skills-skilldialog/dialog-skill-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/81.skills-skilldialog/dialog-skill-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/servlet-echo/deploymentTemplates/template-with-preexisting-rg-gov.json
+++ b/samples/java_springboot/servlet-echo/deploymentTemplates/template-with-preexisting-rg-gov.json
@@ -132,11 +132,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -144,11 +144,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/java_springboot/servlet-echo/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/servlet-echo/deploymentTemplates/template-with-preexisting-rg.json
@@ -233,11 +233,11 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
@@ -245,11 +245,12 @@
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
                 "endpoint": "[variables('botEndpoint')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"


### PR DESCRIPTION
Addresses # 3340

## Proposed Changes
This PR updates the deployment templates (`template-with-preexisting-rg`) of the bots inside [samples/java_springboot](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/java_springboot) folder to use the new Azure resource `Azure Bot` instead of the Bot Channel Registration.

### Detailed Changes
Updated the ARM templates of the following samples:
- 02.echo-bot
- 03.welcome-user
- 05.multi-turn-prompt
- 06.using-cards
- 07.using-adaptive-cards
- 08.suggested-actions
- 11.qnamaker
- 13.core-bot
- 14.nlp-with-dispatch
- 15.handling-attachments
- 16.proactive-messages
- 17.multilingual-bot
- 18.bot-authentication
- 19.custom-dialogs
- 21.corebot-app-insights
- 23.facebook-events
- 24.bot-authentication-msgraph
- 25.message-reaction
- 43.complex-dialog
- 44.prompt-users-for-input
- 45.state-management
- 46.teams-auth
- 47.inspection
- 49.qnamaker-all-features
- 50.teams-messaging-extensions-search
- 51.teams-messaging-extensions-action
- 52.teams-messaging-extensions-search-auth-config
- 53.teams-messaging-extensions-action-preview
- 54.teams-task-module
- 55.teams-link-unfurling
- 56.teams-file-upload
- 57.teams-conversation-bot
- 58.teams-start-new-thread-in-channel
- 80.skills-skilldialog/dialogRootBot
- 80.skills-skilldialog/dialogSkillBot
- 81.skills-skilldialog/dialog-root-bot
- 81.skills-skilldialog/dialog-skill-bot
- servlet-echo

## Testing
These images show some of the java_springboot samples deployed in Azure and working as expected.
![image](https://user-images.githubusercontent.com/44245136/130274393-35a29d9c-13b8-453a-9454-0c1570abb8b8.png)

