### PR TITLE
[#3349] Samples missing deployment templates (template-with-new-rg) - csharp_dotnetcore

### DIFF
--- a/samples/csharp_dotnetcore/14.nlp-with-orchestrator/DeploymentTemplates/new-rg-parameters.json
+++ b/samples/csharp_dotnetcore/14.nlp-with-orchestrator/DeploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/14.nlp-with-orchestrator/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/14.nlp-with-orchestrator/DeploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new App Service Plan",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "properties": {
+                              "name": "[variables('appServicePlanName')]"
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using the new App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2015-08-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                          "value": "10.14.1"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  },
+                                  "webSocketsEnabled": true
+                              }
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/42.scaleout/DeploymentTemplates/new-rg-parameters.json
+++ b/samples/csharp_dotnetcore/42.scaleout/DeploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/42.scaleout/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/42.scaleout/DeploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new App Service Plan",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "properties": {
+                              "name": "[variables('appServicePlanName')]"
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using the new App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2015-08-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                          "value": "10.14.1"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  },
+                                  "webSocketsEnabled": true
+                              }
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/43.complex-dialog/DeploymentTemplates/new-rg-parameters.json
+++ b/samples/csharp_dotnetcore/43.complex-dialog/DeploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/43.complex-dialog/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/43.complex-dialog/DeploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new App Service Plan",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "properties": {
+                              "name": "[variables('appServicePlanName')]"
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using the new App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2015-08-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                          "value": "10.14.1"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  },
+                                  "webSocketsEnabled": true
+                              }
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/DeploymentTemplates/new-rg-parameters.json
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/DeploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/DeploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new App Service Plan",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "properties": {
+                              "name": "[variables('appServicePlanName')]"
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using the new App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2015-08-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                          "value": "10.14.1"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  },
+                                  "webSocketsEnabled": true
+                              }
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/45.state-management/DeploymentTemplates/new-rg-parameters.json
+++ b/samples/csharp_dotnetcore/45.state-management/DeploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/45.state-management/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/45.state-management/DeploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new App Service Plan",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "properties": {
+                              "name": "[variables('appServicePlanName')]"
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using the new App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2015-08-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                          "value": "10.14.1"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  },
+                                  "webSocketsEnabled": true
+                              }
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/DeploymentTemplates/new-rg-parameters.json
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/DeploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/DeploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new App Service Plan",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "properties": {
+                              "name": "[variables('appServicePlanName')]"
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using the new App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2015-08-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                          "value": "10.14.1"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      },
+                      {
+                          "type": "Microsoft.BotService/botServices/channels",
+                          "apiVersion": "2021-03-01",
+                          "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                          "location": "global",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                          ],
+                          "properties": {
+                              "properties": {
+                                  "enableCalling": false,
+                                  "isEnabled": true
+                              },
+                              "channelName": "MsTeamsChannel"
+                          }
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/DeploymentTemplates/new-rg-parameters.json
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/DeploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/DeploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new App Service Plan",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "properties": {
+                              "name": "[variables('appServicePlanName')]"
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using the new App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2015-08-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                          "value": "10.14.1"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      },
+                      {
+                          "type": "Microsoft.BotService/botServices/channels",
+                          "apiVersion": "2021-03-01",
+                          "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                          "location": "global",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                          ],
+                          "properties": {
+                              "properties": {
+                                  "enableCalling": false,
+                                  "isEnabled": true
+                              },
+                              "channelName": "MsTeamsChannel"
+                          }
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/DeploymentTemplates/new-rg-parameters.json
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/DeploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/DeploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new App Service Plan",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "properties": {
+                              "name": "[variables('appServicePlanName')]"
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using the new App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2015-08-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                          "value": "10.14.1"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      },
+                      {
+                          "type": "Microsoft.BotService/botServices/channels",
+                          "apiVersion": "2021-03-01",
+                          "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                          "location": "global",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                          ],
+                          "properties": {
+                              "properties": {
+                                  "enableCalling": false,
+                                  "isEnabled": true
+                              },
+                              "channelName": "MsTeamsChannel"
+                          }
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/DeploymentTemplates/new-rg-parameters.json
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/DeploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/DeploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new App Service Plan",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "properties": {
+                              "name": "[variables('appServicePlanName')]"
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using the new App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2015-08-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                          "value": "10.14.1"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      },
+                      {
+                          "type": "Microsoft.BotService/botServices/channels",
+                          "apiVersion": "2021-03-01",
+                          "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                          "location": "global",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                          ],
+                          "properties": {
+                              "properties": {
+                                  "enableCalling": false,
+                                  "isEnabled": true
+                              },
+                              "channelName": "MsTeamsChannel"
+                          }
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/54.teams-task-module/DeploymentTemplates/new-rg-parameters.json
+++ b/samples/csharp_dotnetcore/54.teams-task-module/DeploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/54.teams-task-module/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/54.teams-task-module/DeploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new App Service Plan",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "properties": {
+                              "name": "[variables('appServicePlanName')]"
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using the new App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2015-08-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                          "value": "10.14.1"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      },
+                      {
+                          "type": "Microsoft.BotService/botServices/channels",
+                          "apiVersion": "2021-03-01",
+                          "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                          "location": "global",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                          ],
+                          "properties": {
+                              "properties": {
+                                  "enableCalling": false,
+                                  "isEnabled": true
+                              },
+                              "channelName": "MsTeamsChannel"
+                          }
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/56.teams-file-upload/DeploymentTemplates/new-rg-parameters.json
+++ b/samples/csharp_dotnetcore/56.teams-file-upload/DeploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/56.teams-file-upload/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/56.teams-file-upload/DeploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new App Service Plan",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "properties": {
+                              "name": "[variables('appServicePlanName')]"
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using the new App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2015-08-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                          "value": "10.14.1"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      },
+                      {
+                          "type": "Microsoft.BotService/botServices/channels",
+                          "apiVersion": "2021-03-01",
+                          "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                          "location": "global",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                          ],
+                          "properties": {
+                              "properties": {
+                                  "enableCalling": false,
+                                  "isEnabled": true
+                              },
+                              "channelName": "MsTeamsChannel"
+                          }
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}


### PR DESCRIPTION
Addresses # 3349

## Proposed Changes
This PR adds the bots' deployment templates (`template-with-new-rg.json`) under the [samples/csharp_dotnetcore](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/csharp_dotnetcore) folder  using the new Azure Bot resource instead of the Bot Channel Registration.

### Detailed Changes
Added the ARM templates of the following samples:
- 14.nlp-with-orchestrator
- 42.scaleout
- 43.complex-dialog
- 44.prompt-users-for-input
- 45.state-management
- 50.teams-messaging-extensions-search
- 51.teams-messaging-extensions-action
- 52.teams-messaging-extensions-search-auth-config
- 53.teams-messaging-extensions-action-preview
- 54.teams-task-module
- 56.teams-file-upload

Bot that were not added:
- 01.console-echo => Console Bot
- 13.core-bot.tests => Test project of the core-bot
- 40.timex-resolution => Console Bot

## Testing
The following images show two bots working with the new ARM Templates.
![image](https://user-images.githubusercontent.com/62260472/131033311-d45aa863-6415-44ed-8c35-8341c8cd2255.png)
![image](https://user-images.githubusercontent.com/62260472/131033323-400540b1-7073-4b8b-bf60-398e6599d9d9.png)
