### PR TITLE
[#3349] Samples missing deployment templates (template-with-preexisting-rg) - csharp_dotnetcore

### DIFF
--- a/samples/csharp_dotnetcore/14.nlp-with-orchestrator/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_dotnetcore/14.nlp-with-orchestrator/DeploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/14.nlp-with-orchestrator/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/14.nlp-with-orchestrator/DeploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "condition": "[not(variables('useExistingAppServicePlan'))]",
+          "name": "[variables('servicePlanName')]",
+          "apiVersion": "2018-02-01",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "properties": {
+              "name": "[variables('servicePlanName')]"
+          }
+      },
+      {
+          "comments": "Create a Web App using an App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2015-08-01",
+          "location": "[variables('resourcesLocation')]",
+          "kind": "app",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "name": "[variables('webAppName')]",
+          "properties": {
+              "name": "[variables('webAppName')]",
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                          "value": "10.14.1"
+                      },
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  },
+                  "webSocketsEnabled": true
+              }
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "endpoint": "[variables('botEndpoint')]",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/42.scaleout/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_dotnetcore/42.scaleout/DeploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/42.scaleout/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/42.scaleout/DeploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "condition": "[not(variables('useExistingAppServicePlan'))]",
+          "name": "[variables('servicePlanName')]",
+          "apiVersion": "2018-02-01",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "properties": {
+              "name": "[variables('servicePlanName')]"
+          }
+      },
+      {
+          "comments": "Create a Web App using an App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2015-08-01",
+          "location": "[variables('resourcesLocation')]",
+          "kind": "app",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "name": "[variables('webAppName')]",
+          "properties": {
+              "name": "[variables('webAppName')]",
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                          "value": "10.14.1"
+                      },
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  },
+                  "webSocketsEnabled": true
+              }
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "endpoint": "[variables('botEndpoint')]",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/43.complex-dialog/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_dotnetcore/43.complex-dialog/DeploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/43.complex-dialog/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/43.complex-dialog/DeploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "condition": "[not(variables('useExistingAppServicePlan'))]",
+          "name": "[variables('servicePlanName')]",
+          "apiVersion": "2018-02-01",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "properties": {
+              "name": "[variables('servicePlanName')]"
+          }
+      },
+      {
+          "comments": "Create a Web App using an App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2015-08-01",
+          "location": "[variables('resourcesLocation')]",
+          "kind": "app",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "name": "[variables('webAppName')]",
+          "properties": {
+              "name": "[variables('webAppName')]",
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                          "value": "10.14.1"
+                      },
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  },
+                  "webSocketsEnabled": true
+              }
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "endpoint": "[variables('botEndpoint')]",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/DeploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/DeploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "condition": "[not(variables('useExistingAppServicePlan'))]",
+          "name": "[variables('servicePlanName')]",
+          "apiVersion": "2018-02-01",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "properties": {
+              "name": "[variables('servicePlanName')]"
+          }
+      },
+      {
+          "comments": "Create a Web App using an App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2015-08-01",
+          "location": "[variables('resourcesLocation')]",
+          "kind": "app",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "name": "[variables('webAppName')]",
+          "properties": {
+              "name": "[variables('webAppName')]",
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                          "value": "10.14.1"
+                      },
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  },
+                  "webSocketsEnabled": true
+              }
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "endpoint": "[variables('botEndpoint')]",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/45.state-management/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_dotnetcore/45.state-management/DeploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/45.state-management/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/45.state-management/DeploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "condition": "[not(variables('useExistingAppServicePlan'))]",
+          "name": "[variables('servicePlanName')]",
+          "apiVersion": "2018-02-01",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "properties": {
+              "name": "[variables('servicePlanName')]"
+          }
+      },
+      {
+          "comments": "Create a Web App using an App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2015-08-01",
+          "location": "[variables('resourcesLocation')]",
+          "kind": "app",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "name": "[variables('webAppName')]",
+          "properties": {
+              "name": "[variables('webAppName')]",
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                          "value": "10.14.1"
+                      },
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  },
+                  "webSocketsEnabled": true
+              }
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "endpoint": "[variables('botEndpoint')]",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/DeploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/DeploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "condition": "[not(variables('useExistingAppServicePlan'))]",
+          "name": "[variables('servicePlanName')]",
+          "apiVersion": "2018-02-01",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "properties": {
+              "name": "[variables('servicePlanName')]"
+          }
+      },
+      {
+          "comments": "Create a Web App using an App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2015-08-01",
+          "location": "[variables('resourcesLocation')]",
+          "kind": "app",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "name": "[variables('webAppName')]",
+          "properties": {
+              "name": "[variables('webAppName')]",
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                          "value": "10.14.1"
+                      },
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  }
+              }
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "endpoint": "[variables('botEndpoint')]",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      },
+      {
+          "type": "Microsoft.BotService/botServices/channels",
+          "apiVersion": "2021-03-01",
+          "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+          "location": "global",
+          "dependsOn": [
+              "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+          ],
+          "properties": {
+              "properties": {
+                  "enableCalling": false,
+                  "isEnabled": true
+              },
+              "channelName": "MsTeamsChannel"
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/DeploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/DeploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "condition": "[not(variables('useExistingAppServicePlan'))]",
+          "name": "[variables('servicePlanName')]",
+          "apiVersion": "2018-02-01",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "properties": {
+              "name": "[variables('servicePlanName')]"
+          }
+      },
+      {
+          "comments": "Create a Web App using an App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2015-08-01",
+          "location": "[variables('resourcesLocation')]",
+          "kind": "app",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "name": "[variables('webAppName')]",
+          "properties": {
+              "name": "[variables('webAppName')]",
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                          "value": "10.14.1"
+                      },
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  }
+              }
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "endpoint": "[variables('botEndpoint')]",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      },
+      {
+          "type": "Microsoft.BotService/botServices/channels",
+          "apiVersion": "2021-03-01",
+          "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+          "location": "global",
+          "dependsOn": [
+              "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+          ],
+          "properties": {
+              "properties": {
+                  "enableCalling": false,
+                  "isEnabled": true
+              },
+              "channelName": "MsTeamsChannel"
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/DeploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/DeploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "condition": "[not(variables('useExistingAppServicePlan'))]",
+          "name": "[variables('servicePlanName')]",
+          "apiVersion": "2018-02-01",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "properties": {
+              "name": "[variables('servicePlanName')]"
+          }
+      },
+      {
+          "comments": "Create a Web App using an App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2015-08-01",
+          "location": "[variables('resourcesLocation')]",
+          "kind": "app",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "name": "[variables('webAppName')]",
+          "properties": {
+              "name": "[variables('webAppName')]",
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                          "value": "10.14.1"
+                      },
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  }
+              }
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "endpoint": "[variables('botEndpoint')]",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      },
+      {
+          "type": "Microsoft.BotService/botServices/channels",
+          "apiVersion": "2021-03-01",
+          "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+          "location": "global",
+          "dependsOn": [
+              "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+          ],
+          "properties": {
+              "properties": {
+                  "enableCalling": false,
+                  "isEnabled": true
+              },
+              "channelName": "MsTeamsChannel"
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/DeploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/DeploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "condition": "[not(variables('useExistingAppServicePlan'))]",
+          "name": "[variables('servicePlanName')]",
+          "apiVersion": "2018-02-01",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "properties": {
+              "name": "[variables('servicePlanName')]"
+          }
+      },
+      {
+          "comments": "Create a Web App using an App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2015-08-01",
+          "location": "[variables('resourcesLocation')]",
+          "kind": "app",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "name": "[variables('webAppName')]",
+          "properties": {
+              "name": "[variables('webAppName')]",
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                          "value": "10.14.1"
+                      },
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  }
+              }
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "endpoint": "[variables('botEndpoint')]",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      },
+      {
+          "type": "Microsoft.BotService/botServices/channels",
+          "apiVersion": "2021-03-01",
+          "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+          "location": "global",
+          "dependsOn": [
+              "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+          ],
+          "properties": {
+              "properties": {
+                  "enableCalling": false,
+                  "isEnabled": true
+              },
+              "channelName": "MsTeamsChannel"
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/54.teams-task-module/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_dotnetcore/54.teams-task-module/DeploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/54.teams-task-module/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/54.teams-task-module/DeploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "condition": "[not(variables('useExistingAppServicePlan'))]",
+          "name": "[variables('servicePlanName')]",
+          "apiVersion": "2018-02-01",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "properties": {
+              "name": "[variables('servicePlanName')]"
+          }
+      },
+      {
+          "comments": "Create a Web App using an App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2015-08-01",
+          "location": "[variables('resourcesLocation')]",
+          "kind": "app",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "name": "[variables('webAppName')]",
+          "properties": {
+              "name": "[variables('webAppName')]",
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                          "value": "10.14.1"
+                      },
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  }
+              }
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "endpoint": "[variables('botEndpoint')]",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      },
+      {
+          "type": "Microsoft.BotService/botServices/channels",
+          "apiVersion": "2021-03-01",
+          "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+          "location": "global",
+          "dependsOn": [
+              "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+          ],
+          "properties": {
+              "properties": {
+                  "enableCalling": false,
+                  "isEnabled": true
+              },
+              "channelName": "MsTeamsChannel"
+          }
+      }
+  ]
+}

--- a/samples/csharp_dotnetcore/56.teams-file-upload/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_dotnetcore/56.teams-file-upload/DeploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/56.teams-file-upload/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/56.teams-file-upload/DeploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "condition": "[not(variables('useExistingAppServicePlan'))]",
+          "name": "[variables('servicePlanName')]",
+          "apiVersion": "2018-02-01",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "properties": {
+              "name": "[variables('servicePlanName')]"
+          }
+      },
+      {
+          "comments": "Create a Web App using an App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2015-08-01",
+          "location": "[variables('resourcesLocation')]",
+          "kind": "app",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "name": "[variables('webAppName')]",
+          "properties": {
+              "name": "[variables('webAppName')]",
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                          "value": "10.14.1"
+                      },
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  }
+              }
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "endpoint": "[variables('botEndpoint')]",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      },
+      {
+          "type": "Microsoft.BotService/botServices/channels",
+          "apiVersion": "2021-03-01",
+          "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+          "location": "global",
+          "dependsOn": [
+              "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+          ],
+          "properties": {
+              "properties": {
+                  "enableCalling": false,
+                  "isEnabled": true
+              },
+              "channelName": "MsTeamsChannel"
+          }
+      }
+  ]
+}


### PR DESCRIPTION
Addresses # 3349

## Proposed Changes
This PR adds the bots' deployment templates (`template-with-preexisting-rg.json`) under the [samples/csharp_dotnetcore](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/csharp_dotnetcore) folder using the new Azure Bot resource instead of the Bot Channel Registration.

### Detailed Changes
Added the ARM templates of the following samples:
- 14.nlp-with-orchestrator
- 42.scaleout
- 43.complex-dialog
- 44.prompt-users-for-input
- 45.state-management
- 50.teams-messaging-extensions-search
- 51.teams-messaging-extensions-action
- 52.teams-messaging-extensions-search-auth-config
- 53.teams-messaging-extensions-action-preview
- 54.teams-task-module
- 56.teams-file-upload

Bot that were not added:
- 01.console-echo => Console Bot
- 13.core-bot.tests => Test project of the core-bot
- 40.timex-resolution => Console Bot

## Testing
The following image shows two bots working with the new ARM Templates.
![image](https://user-images.githubusercontent.com/62260472/131034144-d98ab02c-58da-490b-997e-bb51002675d9.png)
