### PR TITLE
[#3349] Samples missing deployment templates - remaining bots

### DIFF
--- a/samples/csharp_webapi/13.core-bot/DeploymentTemplates/new-rg-parameters.json
+++ b/samples/csharp_webapi/13.core-bot/DeploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_webapi/13.core-bot/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_webapi/13.core-bot/DeploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/csharp_webapi/13.core-bot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_webapi/13.core-bot/DeploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new App Service Plan",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "properties": {
+                              "name": "[variables('appServicePlanName')]"
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using the new App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2015-08-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                          "value": "10.14.1"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  },
+                                  "webSocketsEnabled": true
+                              }
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}

--- a/samples/csharp_webapi/13.core-bot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_webapi/13.core-bot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "condition": "[not(variables('useExistingAppServicePlan'))]",
+          "name": "[variables('servicePlanName')]",
+          "apiVersion": "2018-02-01",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "properties": {
+              "name": "[variables('servicePlanName')]"
+          }
+      },
+      {
+          "comments": "Create a Web App using an App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2015-08-01",
+          "location": "[variables('resourcesLocation')]",
+          "kind": "app",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "name": "[variables('webAppName')]",
+          "properties": {
+              "name": "[variables('webAppName')]",
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                          "value": "10.14.1"
+                      },
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  },
+                  "webSocketsEnabled": true
+              }
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "endpoint": "[variables('botEndpoint')]",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      }
+  ]
+}

--- a/samples/java_springboot/42.scaleout/deploymentTemplates/template-with-new-rg.json
+++ b/samples/java_springboot/42.scaleout/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,292 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "defaultValue": "",
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "S1",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "defaultValue": "",
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "P1v2",
+              "tier": "PremiumV2",
+              "size": "P1v2",
+              "family": "Pv2",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "defaultValue": "",
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "publishingUsername": "[concat('$', parameters('newWebAppName'))]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new Linux App Service Plan if no existing App Service Plan name was passed in.",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "kind": "linux",
+                          "properties": {
+                              "perSiteScaling": false,
+                              "maximumElasticWorkerCount": 1,
+                              "isSpot": false,
+                              "reserved": true,
+                              "isXenon": false,
+                              "hyperV": false,
+                              "targetWorkerCount": 0,
+                              "targetWorkerSizeId": 0
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using a Linux App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2018-11-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app,linux",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "hostNameSslStates": [
+                                  {
+                                      "name": "[concat(parameters('newWebAppName'), '.azurewebsites.net')]",
+                                      "sslState": "Disabled",
+                                      "hostType": "Standard"
+                                  },
+                                  {
+                                      "name": "[concat(parameters('newWebAppName'), '.scm.azurewebsites.net')]",
+                                      "sslState": "Disabled",
+                                      "hostType": "Repository"
+                                  }
+                              ],
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "reserved": true,
+                              "isXenon": false,
+                              "hyperV": false,
+                              "scmSiteAlsoStopped": false,
+                              "clientAffinityEnabled": true,
+                              "clientCertEnabled": false,
+                              "hostNamesDisabled": false,
+                              "containerSize": 0,
+                              "dailyMemoryTimeQuota": 0,
+                              "httpsOnly": false,
+                              "redundancyMode": "None",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "JAVA_OPTS",
+                                          "value": "-Dserver.port=80"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "type": "Microsoft.Web/sites/config",
+                          "apiVersion": "2018-11-01",
+                          "name": "[concat(variables('webAppName'), '/web')]",
+                          "location": "[variables('resourcesLocation')]",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ],
+                          "properties": {
+                              "numberOfWorkers": 1,
+                              "defaultDocuments": [
+                                  "Default.htm",
+                                  "Default.html",
+                                  "Default.asp",
+                                  "index.htm",
+                                  "index.html",
+                                  "iisstart.htm",
+                                  "default.aspx",
+                                  "index.php",
+                                  "hostingstart.html"
+                              ],
+                              "netFrameworkVersion": "v4.0",
+                              "linuxFxVersion": "JAVA|8-jre8",
+                              "requestTracingEnabled": false,
+                              "remoteDebuggingEnabled": false,
+                              "httpLoggingEnabled": false,
+                              "logsDirectorySizeLimit": 35,
+                              "detailedErrorLoggingEnabled": false,
+                              "publishingUsername": "[variables('publishingUsername')]",
+                              "scmType": "None",
+                              "use32BitWorkerProcess": true,
+                              "webSocketsEnabled": false,
+                              "alwaysOn": true,
+                              "managedPipelineMode": "Integrated",
+                              "virtualApplications": [
+                                  {
+                                      "virtualPath": "/",
+                                      "physicalPath": "site\\wwwroot",
+                                      "preloadEnabled": true
+                                  }
+                              ],
+                              "loadBalancing": "LeastRequests",
+                              "experiments": {
+                                  "rampUpRules": []
+                              },
+                              "autoHealEnabled": false,
+                              "localMySqlEnabled": false,
+                              "ipSecurityRestrictions": [
+                                  {
+                                      "ipAddress": "Any",
+                                      "action": "Allow",
+                                      "priority": 1,
+                                      "name": "Allow all",
+                                      "description": "Allow all access"
+                                  }
+                              ],
+                              "scmIpSecurityRestrictions": [
+                                  {
+                                      "ipAddress": "Any",
+                                      "action": "Allow",
+                                      "priority": 1,
+                                      "name": "Allow all",
+                                      "description": "Allow all access"
+                                  }
+                              ],
+                              "scmIpSecurityRestrictionsUseMain": false,
+                              "http20Enabled": false,
+                              "minTlsVersion": "1.2",
+                              "ftpsState": "AllAllowed",
+                              "reservedInstanceCount": 0
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}

--- a/samples/java_springboot/42.scaleout/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/42.scaleout/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,260 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "S1",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "P1v2",
+              "tier": "PremiumV2",
+              "size": "P1v2",
+              "family": "Pv2",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "publishingUsername": "[concat('$', parameters('newWebAppName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new Linux App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "condition": "[not(variables('useExistingAppServicePlan'))]",
+          "name": "[variables('servicePlanName')]",
+          "apiVersion": "2018-02-01",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "kind": "linux",
+          "properties": {
+              "perSiteScaling": false,
+              "maximumElasticWorkerCount": 1,
+              "isSpot": false,
+              "reserved": true,
+              "isXenon": false,
+              "hyperV": false,
+              "targetWorkerCount": 0,
+              "targetWorkerSizeId": 0
+          }
+      },
+      {
+          "comments": "Create a Web App using a Linux App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2018-11-01",
+          "location": "[variables('resourcesLocation')]",
+          "kind": "app,linux",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "name": "[variables('webAppName')]",
+          "properties": {
+              "name": "[variables('webAppName')]",
+              "hostNameSslStates": [
+                  {
+                      "name": "[concat(parameters('newWebAppName'), '.azurewebsites.net')]",
+                      "sslState": "Disabled",
+                      "hostType": "Standard"
+                  },
+                  {
+                      "name": "[concat(parameters('newWebAppName'), '.scm.azurewebsites.net')]",
+                      "sslState": "Disabled",
+                      "hostType": "Repository"
+                  }
+              ],
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "reserved": true,
+              "isXenon": false,
+              "hyperV": false,
+              "scmSiteAlsoStopped": false,
+              "clientAffinityEnabled": true,
+              "clientCertEnabled": false,
+              "hostNamesDisabled": false,
+              "containerSize": 0,
+              "dailyMemoryTimeQuota": 0,
+              "httpsOnly": false,
+              "redundancyMode": "None",
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "JAVA_OPTS",
+                          "value": "-Dserver.port=80"
+                      },
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  }
+              }
+          }
+      },
+      {
+          "type": "Microsoft.Web/sites/config",
+          "apiVersion": "2018-11-01",
+          "name": "[concat(variables('webAppName'), '/web')]",
+          "location": "[variables('resourcesLocation')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ],
+          "properties": {
+              "numberOfWorkers": 1,
+              "defaultDocuments": [
+                  "Default.htm",
+                  "Default.html",
+                  "Default.asp",
+                  "index.htm",
+                  "index.html",
+                  "iisstart.htm",
+                  "default.aspx",
+                  "index.php",
+                  "hostingstart.html"
+              ],
+              "netFrameworkVersion": "v4.0",
+              "linuxFxVersion": "JAVA|8-jre8",
+              "requestTracingEnabled": false,
+              "remoteDebuggingEnabled": false,
+              "httpLoggingEnabled": false,
+              "logsDirectorySizeLimit": 35,
+              "detailedErrorLoggingEnabled": false,
+              "publishingUsername": "[variables('publishingUsername')]",
+              "scmType": "None",
+              "use32BitWorkerProcess": true,
+              "webSocketsEnabled": false,
+              "alwaysOn": true,
+              "managedPipelineMode": "Integrated",
+              "virtualApplications": [
+                  {
+                      "virtualPath": "/",
+                      "physicalPath": "site\\wwwroot",
+                      "preloadEnabled": true
+                  }
+              ],
+              "loadBalancing": "LeastRequests",
+              "experiments": {
+                  "rampUpRules": []
+              },
+              "autoHealEnabled": false,
+              "localMySqlEnabled": false,
+              "ipSecurityRestrictions": [
+                  {
+                      "ipAddress": "Any",
+                      "action": "Allow",
+                      "priority": 1,
+                      "name": "Allow all",
+                      "description": "Allow all access"
+                  }
+              ],
+              "scmIpSecurityRestrictions": [
+                  {
+                      "ipAddress": "Any",
+                      "action": "Allow",
+                      "priority": 1,
+                      "name": "Allow all",
+                      "description": "Allow all access"
+                  }
+              ],
+              "scmIpSecurityRestrictionsUseMain": false,
+              "http20Enabled": false,
+              "minTlsVersion": "1.2",
+              "ftpsState": "AllAllowed",
+              "reservedInstanceCount": 0
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "endpoint": "[variables('botEndpoint')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      }
+  ]
+}

--- a/samples/python/wip/python_django/13.core-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/wip/python_django/13.core-bot/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,265 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "groupLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the location of the Resource Group."
+          }
+      },
+      "groupName": {
+          "type": "string",
+          "metadata": {
+              "description": "Specifies the name of the Resource Group."
+          }
+      },
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "newAppServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan. Defaults to \"westus\"."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "appServicePlanName": "[parameters('newAppServicePlanName')]",
+      "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+      "publishingUsername": "[concat('$', parameters('newWebAppName'))]",
+      "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+      {
+          "name": "[parameters('groupName')]",
+          "type": "Microsoft.Resources/resourceGroups",
+          "apiVersion": "2018-05-01",
+          "location": "[parameters('groupLocation')]",
+          "properties": {}
+      },
+      {
+          "type": "Microsoft.Resources/deployments",
+          "apiVersion": "2018-05-01",
+          "name": "storageDeployment",
+          "resourceGroup": "[parameters('groupName')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {},
+                  "variables": {},
+                  "resources": [
+                      {
+                          "comments": "Create a new Linux App Service Plan if no existing App Service Plan name was passed in.",
+                          "type": "Microsoft.Web/serverfarms",
+                          "name": "[variables('appServicePlanName')]",
+                          "apiVersion": "2018-02-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "sku": "[parameters('newAppServicePlanSku')]",
+                          "kind": "linux",
+                          "properties": {
+                              "name": "[variables('appServicePlanName')]",
+                              "perSiteScaling": false,
+                              "reserved": true,
+                              "targetWorkerCount": 0,
+                              "targetWorkerSizeId": 0
+                          }
+                      },
+                      {
+                          "comments": "Create a Web App using a Linux App Service Plan",
+                          "type": "Microsoft.Web/sites",
+                          "apiVersion": "2015-08-01",
+                          "location": "[variables('resourcesLocation')]",
+                          "kind": "app,linux",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                          ],
+                          "name": "[variables('webAppName')]",
+                          "properties": {
+                              "name": "[variables('webAppName')]",
+                              "hostNameSslStates": [
+                                  {
+                                      "name": "[concat(parameters('newWebAppName'), '.azurewebsites.net')]",
+                                      "sslState": "Disabled",
+                                      "hostType": "Standard"
+                                  },
+                                  {
+                                      "name": "[concat(parameters('newWebAppName'), '.scm.azurewebsites.net')]",
+                                      "sslState": "Disabled",
+                                      "hostType": "Repository"
+                                  }
+                              ],
+                              "serverFarmId": "[variables('appServicePlanName')]",
+                              "siteConfig": {
+                                  "appSettings": [
+                                      {
+                                          "name": "SCM_DO_BUILD_DURING_DEPLOYMENT",
+                                          "value": "true"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppId",
+                                          "value": "[parameters('appId')]"
+                                      },
+                                      {
+                                          "name": "MicrosoftAppPassword",
+                                          "value": "[parameters('appSecret')]"
+                                      }
+                                  ],
+                                  "cors": {
+                                      "allowedOrigins": [
+                                          "https://botservice.hosting.portal.azure.net",
+                                          "https://hosting.onecloud.azure-test.net/"
+                                      ]
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "type": "Microsoft.Web/sites/config",
+                          "apiVersion": "2016-08-01",
+                          "name": "[concat(variables('webAppName'), '/web')]",
+                          "location": "[variables('resourcesLocation')]",
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ],
+                          "properties": {
+                              "numberOfWorkers": 1,
+                              "defaultDocuments": [
+                                  "Default.htm",
+                                  "Default.html",
+                                  "Default.asp",
+                                  "index.htm",
+                                  "index.html",
+                                  "iisstart.htm",
+                                  "default.aspx",
+                                  "index.php",
+                                  "hostingstart.html"
+                              ],
+                              "netFrameworkVersion": "v4.0",
+                              "phpVersion": "",
+                              "pythonVersion": "",
+                              "nodeVersion": "",
+                              "linuxFxVersion": "PYTHON|3.7",
+                              "requestTracingEnabled": false,
+                              "remoteDebuggingEnabled": false,
+                              "remoteDebuggingVersion": "VS2017",
+                              "httpLoggingEnabled": true,
+                              "logsDirectorySizeLimit": 35,
+                              "detailedErrorLoggingEnabled": false,
+                              "publishingUsername": "[variables('publishingUsername')]",
+                              "scmType": "None",
+                              "use32BitWorkerProcess": true,
+                              "webSocketsEnabled": false,
+                              "alwaysOn": false,
+                              "appCommandLine": "gunicorn --bind 0.0.0.0 --worker-class aiohttp.worker.GunicornWebWorker --timeout 600 app:APP",
+                              "managedPipelineMode": "Integrated",
+                              "virtualApplications": [
+                                  {
+                                      "virtualPath": "/",
+                                      "physicalPath": "site\\wwwroot",
+                                      "preloadEnabled": false,
+                                      "virtualDirectories": null
+                                  }
+                              ],
+                              "winAuthAdminState": 0,
+                              "winAuthTenantState": 0,
+                              "customAppPoolIdentityAdminState": false,
+                              "customAppPoolIdentityTenantState": false,
+                              "loadBalancing": "LeastRequests",
+                              "routingRules": [],
+                              "experiments": {
+                                  "rampUpRules": []
+                              },
+                              "autoHealEnabled": false,
+                              "vnetName": "",
+                              "minTlsVersion": "1.2",
+                              "ftpsState": "AllAllowed",
+                              "reservedInstanceCount": 0
+                          }
+                      },
+                      {
+                          "apiVersion": "2021-03-01",
+                          "type": "Microsoft.BotService/botServices",
+                          "name": "[parameters('botId')]",
+                          "location": "global",
+                          "kind": "azurebot",
+                          "sku": {
+                              "name": "[parameters('botSku')]"
+                          },
+                          "properties": {
+                              "name": "[parameters('botId')]",
+                              "displayName": "[parameters('botId')]",
+                              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                              "endpoint": "[variables('botEndpoint')]",
+                              "msaAppId": "[parameters('appId')]",
+                              "luisAppIds": [],
+                              "schemaTransformationVersion": "1.3",
+                              "isCmekEnabled": false,
+                              "isIsolated": false
+                          },
+                          "dependsOn": [
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                          ]
+                      }
+                  ],
+                  "outputs": {}
+              }
+          }
+      }
+  ]
+}

--- a/samples/python/wip/python_django/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/wip/python_django/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+      "appId": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+          }
+      },
+      "appSecret": {
+          "type": "string",
+          "metadata": {
+              "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+          }
+      },
+      "botId": {
+          "type": "string",
+          "metadata": {
+              "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+          }
+      },
+      "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+              "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+      },
+      "newAppServicePlanName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The name of the new App Service Plan."
+          }
+      },
+      "newAppServicePlanSku": {
+          "type": "object",
+          "defaultValue": {
+              "name": "S1",
+              "tier": "Standard",
+              "size": "S1",
+              "family": "S",
+              "capacity": 1
+          },
+          "metadata": {
+              "description": "The SKU of the App Service Plan. Defaults to Standard values."
+          }
+      },
+      "appServicePlanLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The location of the App Service Plan."
+          }
+      },
+      "existingAppServicePlan": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+          }
+      },
+      "newWebAppName": {
+          "type": "string",
+          "defaultValue": "",
+          "metadata": {
+              "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+          }
+      }
+  },
+  "variables": {
+      "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+      "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+      "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+      "publishingUsername": "[concat('$', parameters('newWebAppName'))]",
+      "resourcesLocation": "[parameters('appServicePlanLocation')]",
+      "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+      "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+      "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+      {
+          "comments": "Create a new Linux App Service Plan if no existing App Service Plan name was passed in.",
+          "type": "Microsoft.Web/serverfarms",
+          "apiVersion": "2016-09-01",
+          "name": "[variables('servicePlanName')]",
+          "location": "[variables('resourcesLocation')]",
+          "sku": "[parameters('newAppServicePlanSku')]",
+          "kind": "linux",
+          "properties": {
+              "name": "[variables('servicePlanName')]",
+              "perSiteScaling": false,
+              "reserved": true,
+              "targetWorkerCount": 0,
+              "targetWorkerSizeId": 0
+          }
+      },
+      {
+          "comments": "Create a Web App using a Linux App Service Plan",
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2016-08-01",
+          "name": "[variables('webAppName')]",
+          "location": "[variables('resourcesLocation')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+          ],
+          "kind": "app,linux",
+          "properties": {
+              "enabled": true,
+              "hostNameSslStates": [
+                  {
+                      "name": "[concat(parameters('newWebAppName'), '.azurewebsites.net')]",
+                      "sslState": "Disabled",
+                      "hostType": "Standard"
+                  },
+                  {
+                      "name": "[concat(parameters('newWebAppName'), '.scm.azurewebsites.net')]",
+                      "sslState": "Disabled",
+                      "hostType": "Repository"
+                  }
+              ],
+              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+              "reserved": true,
+              "scmSiteAlsoStopped": false,
+              "clientAffinityEnabled": false,
+              "clientCertEnabled": false,
+              "hostNamesDisabled": false,
+              "containerSize": 0,
+              "dailyMemoryTimeQuota": 0,
+              "httpsOnly": false,
+              "siteConfig": {
+                  "appSettings": [
+                      {
+                          "name": "MicrosoftAppId",
+                          "value": "[parameters('appId')]"
+                      },
+                      {
+                          "name": "MicrosoftAppPassword",
+                          "value": "[parameters('appSecret')]"
+                      },
+                      {
+                          "name": "SCM_DO_BUILD_DURING_DEPLOYMENT",
+                          "value": "true"
+                      }
+                  ],
+                  "cors": {
+                      "allowedOrigins": [
+                          "https://botservice.hosting.portal.azure.net",
+                          "https://hosting.onecloud.azure-test.net/"
+                      ]
+                  }
+              }
+          }
+      },
+      {
+          "type": "Microsoft.Web/sites/config",
+          "apiVersion": "2016-08-01",
+          "name": "[concat(variables('webAppName'), '/web')]",
+          "location": "[variables('resourcesLocation')]",
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites', variables('webAppName'))]"
+          ],
+          "properties": {
+              "numberOfWorkers": 1,
+              "defaultDocuments": [
+                  "Default.htm",
+                  "Default.html",
+                  "Default.asp",
+                  "index.htm",
+                  "index.html",
+                  "iisstart.htm",
+                  "default.aspx",
+                  "index.php",
+                  "hostingstart.html"
+              ],
+              "netFrameworkVersion": "v4.0",
+              "phpVersion": "",
+              "pythonVersion": "",
+              "nodeVersion": "",
+              "linuxFxVersion": "PYTHON|3.7",
+              "requestTracingEnabled": false,
+              "remoteDebuggingEnabled": false,
+              "remoteDebuggingVersion": "VS2017",
+              "httpLoggingEnabled": true,
+              "logsDirectorySizeLimit": 35,
+              "detailedErrorLoggingEnabled": false,
+              "publishingUsername": "[variables('publishingUsername')]",
+              "scmType": "None",
+              "use32BitWorkerProcess": true,
+              "webSocketsEnabled": false,
+              "alwaysOn": false,
+              "appCommandLine": "gunicorn --bind 0.0.0.0 --worker-class aiohttp.worker.GunicornWebWorker --timeout 600 app:APP",
+              "managedPipelineMode": "Integrated",
+              "virtualApplications": [
+                  {
+                      "virtualPath": "/",
+                      "physicalPath": "site\\wwwroot",
+                      "preloadEnabled": false,
+                      "virtualDirectories": null
+                  }
+              ],
+              "winAuthAdminState": 0,
+              "winAuthTenantState": 0,
+              "customAppPoolIdentityAdminState": false,
+              "customAppPoolIdentityTenantState": false,
+              "loadBalancing": "LeastRequests",
+              "routingRules": [],
+              "experiments": {
+                  "rampUpRules": []
+              },
+              "autoHealEnabled": false,
+              "vnetName": "",
+              "minTlsVersion": "1.2",
+              "ftpsState": "AllAllowed",
+              "reservedInstanceCount": 0
+          }
+      },
+      {
+          "apiVersion": "2021-03-01",
+          "type": "Microsoft.BotService/botServices",
+          "name": "[parameters('botId')]",
+          "location": "global",
+          "kind": "azurebot",
+          "sku": {
+              "name": "[parameters('botSku')]"
+          },
+          "properties": {
+              "name": "[parameters('botId')]",
+              "displayName": "[parameters('botId')]",
+              "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+              "endpoint": "[variables('botEndpoint')]",
+              "msaAppId": "[parameters('appId')]",
+              "luisAppIds": [],
+              "schemaTransformationVersion": "1.3",
+              "isCmekEnabled": false,
+              "isIsolated": false
+          },
+          "dependsOn": [
+              "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+          ]
+      }
+  ]
+}


### PR DESCRIPTION
Addresses # 3349

## Proposed Changes
This PR adds the bots' deployment templates under the [samples](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples) folder  using the new Azure Bot resource instead of the Bot Channel Registration.

### Detailed Changes
Added the ARM templates of the following samples:
- csharp_webapi/13.core-bot
- java_springboot/42.scaleout
- python/wip/python_django/13.core-bot

Bot that were not added:
- javascript_es6/01.browser-echo => WebChat website, doesn't use Azure Bot.
- javascript_es6/70.styling-webchat => WebChat website, doesn't use Azure Bot.
- java_springboot/40.timex-resolution => Console Bot
- python/01.console-echo => Console Bot
- python/40.timex-resolution => Console Bot
- typescript_nodejs/01.console-echo => Console Bot

## Testing
The following image shows the `java_springboot/42.scaleout` bot working with the new ARM Templates.
![imagen](https://user-images.githubusercontent.com/62260472/131370905-5eead073-9ab2-4f8f-a12f-6869133844ab.png)
