### PR TITLE
[#3349] Samples missing deployment templates (template-with-new-rg) - javascript_nodejs

### DIFF
--- a/samples/javascript_nodejs/14.nlp-with-orchestrator/deploymentTemplates/new-rg-parameters.json
+++ b/samples/javascript_nodejs/14.nlp-with-orchestrator/deploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/14.nlp-with-orchestrator/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/14.nlp-with-orchestrator/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,184 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location of the Resource Group."
+            }
+        },
+        "groupName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Resource Group."
+            }
+        },
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "newAppServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan. Defaults to \"westus\"."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        }
+    },
+    "variables": {
+        "appServicePlanName": "[parameters('newAppServicePlanName')]",
+        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+    },
+    "resources": [
+        {
+            "name": "[parameters('groupName')]",
+            "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2018-05-01",
+            "location": "[parameters('groupLocation')]",
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "storageDeployment",
+            "resourceGroup": "[parameters('groupName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "comments": "Create a new App Service Plan",
+                            "type": "Microsoft.Web/serverfarms",
+                            "name": "[variables('appServicePlanName')]",
+                            "apiVersion": "2018-02-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "properties": {
+                                "name": "[variables('appServicePlanName')]"
+                            }
+                        },
+                        {
+                            "comments": "Create a Web App using the new App Service Plan",
+                            "type": "Microsoft.Web/sites",
+                            "apiVersion": "2015-08-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "kind": "app",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                            ],
+                            "name": "[variables('webAppName')]",
+                            "properties": {
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "siteConfig": {
+                                    "appSettings": [
+                                        {
+                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                            "value": "10.14.1"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppId",
+                                            "value": "[parameters('appId')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppPassword",
+                                            "value": "[parameters('appSecret')]"
+                                        }
+                                    ],
+                                    "cors": {
+                                        "allowedOrigins": [
+                                            "https://botservice.hosting.portal.azure.net",
+                                            "https://hosting.onecloud.azure-test.net/"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "apiVersion": "2021-03-01",
+                            "type": "Microsoft.BotService/botServices",
+                            "name": "[parameters('botId')]",
+                            "location": "global",
+                            "kind": "azurebot",
+                            "sku": {
+                                "name": "[parameters('botSku')]"
+                            },
+                            "properties": {
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
+                            },
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                            ]
+                        }
+                    ],
+                    "outputs": {}
+                }
+            }
+        }
+    ]
+}

--- a/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/new-rg-parameters.json
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,184 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location of the Resource Group."
+            }
+        },
+        "groupName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Resource Group."
+            }
+        },
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "newAppServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan. Defaults to \"westus\"."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        }
+    },
+    "variables": {
+        "appServicePlanName": "[parameters('newAppServicePlanName')]",
+        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+    },
+    "resources": [
+        {
+            "name": "[parameters('groupName')]",
+            "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2018-05-01",
+            "location": "[parameters('groupLocation')]",
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "storageDeployment",
+            "resourceGroup": "[parameters('groupName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "comments": "Create a new App Service Plan",
+                            "type": "Microsoft.Web/serverfarms",
+                            "name": "[variables('appServicePlanName')]",
+                            "apiVersion": "2018-02-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "properties": {
+                                "name": "[variables('appServicePlanName')]"
+                            }
+                        },
+                        {
+                            "comments": "Create a Web App using the new App Service Plan",
+                            "type": "Microsoft.Web/sites",
+                            "apiVersion": "2015-08-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "kind": "app",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                            ],
+                            "name": "[variables('webAppName')]",
+                            "properties": {
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "siteConfig": {
+                                    "appSettings": [
+                                        {
+                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                            "value": "10.14.1"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppId",
+                                            "value": "[parameters('appId')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppPassword",
+                                            "value": "[parameters('appSecret')]"
+                                        }
+                                    ],
+                                    "cors": {
+                                        "allowedOrigins": [
+                                            "https://botservice.hosting.portal.azure.net",
+                                            "https://hosting.onecloud.azure-test.net/"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "apiVersion": "2021-03-01",
+                            "type": "Microsoft.BotService/botServices",
+                            "name": "[parameters('botId')]",
+                            "location": "global",
+                            "kind": "azurebot",
+                            "sku": {
+                                "name": "[parameters('botSku')]"
+                            },
+                            "properties": {
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
+                            },
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                            ]
+                        }
+                    ],
+                    "outputs": {}
+                }
+            }
+        }
+    ]
+}

--- a/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/new-rg-parameters.json
+++ b/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,184 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location of the Resource Group."
+            }
+        },
+        "groupName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Resource Group."
+            }
+        },
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "newAppServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan. Defaults to \"westus\"."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        }
+    },
+    "variables": {
+        "appServicePlanName": "[parameters('newAppServicePlanName')]",
+        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+    },
+    "resources": [
+        {
+            "name": "[parameters('groupName')]",
+            "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2018-05-01",
+            "location": "[parameters('groupLocation')]",
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "storageDeployment",
+            "resourceGroup": "[parameters('groupName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "comments": "Create a new App Service Plan",
+                            "type": "Microsoft.Web/serverfarms",
+                            "name": "[variables('appServicePlanName')]",
+                            "apiVersion": "2018-02-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "properties": {
+                                "name": "[variables('appServicePlanName')]"
+                            }
+                        },
+                        {
+                            "comments": "Create a Web App using the new App Service Plan",
+                            "type": "Microsoft.Web/sites",
+                            "apiVersion": "2015-08-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "kind": "app",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                            ],
+                            "name": "[variables('webAppName')]",
+                            "properties": {
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "siteConfig": {
+                                    "appSettings": [
+                                        {
+                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                            "value": "10.14.1"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppId",
+                                            "value": "[parameters('appId')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppPassword",
+                                            "value": "[parameters('appSecret')]"
+                                        }
+                                    ],
+                                    "cors": {
+                                        "allowedOrigins": [
+                                            "https://botservice.hosting.portal.azure.net",
+                                            "https://hosting.onecloud.azure-test.net/"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "apiVersion": "2021-03-01",
+                            "type": "Microsoft.BotService/botServices",
+                            "name": "[parameters('botId')]",
+                            "location": "global",
+                            "kind": "azurebot",
+                            "sku": {
+                                "name": "[parameters('botSku')]"
+                            },
+                            "properties": {
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
+                            },
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                            ]
+                        }
+                    ],
+                    "outputs": {}
+                }
+            }
+        }
+    ]
+}

--- a/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/new-rg-parameters.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,184 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location of the Resource Group."
+            }
+        },
+        "groupName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Resource Group."
+            }
+        },
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "newAppServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan. Defaults to \"westus\"."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        }
+    },
+    "variables": {
+        "appServicePlanName": "[parameters('newAppServicePlanName')]",
+        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+    },
+    "resources": [
+        {
+            "name": "[parameters('groupName')]",
+            "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2018-05-01",
+            "location": "[parameters('groupLocation')]",
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "storageDeployment",
+            "resourceGroup": "[parameters('groupName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "comments": "Create a new App Service Plan",
+                            "type": "Microsoft.Web/serverfarms",
+                            "name": "[variables('appServicePlanName')]",
+                            "apiVersion": "2018-02-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "properties": {
+                                "name": "[variables('appServicePlanName')]"
+                            }
+                        },
+                        {
+                            "comments": "Create a Web App using the new App Service Plan",
+                            "type": "Microsoft.Web/sites",
+                            "apiVersion": "2015-08-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "kind": "app",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                            ],
+                            "name": "[variables('webAppName')]",
+                            "properties": {
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "siteConfig": {
+                                    "appSettings": [
+                                        {
+                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                            "value": "10.14.1"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppId",
+                                            "value": "[parameters('appId')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppPassword",
+                                            "value": "[parameters('appSecret')]"
+                                        }
+                                    ],
+                                    "cors": {
+                                        "allowedOrigins": [
+                                            "https://botservice.hosting.portal.azure.net",
+                                            "https://hosting.onecloud.azure-test.net/"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "apiVersion": "2021-03-01",
+                            "type": "Microsoft.BotService/botServices",
+                            "name": "[parameters('botId')]",
+                            "location": "global",
+                            "kind": "azurebot",
+                            "sku": {
+                                "name": "[parameters('botSku')]"
+                            },
+                            "properties": {
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
+                            },
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                            ]
+                        }
+                    ],
+                    "outputs": {}
+                }
+            }
+        }
+    ]
+}

--- a/samples/javascript_nodejs/45.state-management/deploymentTemplates/new-rg-parameters.json
+++ b/samples/javascript_nodejs/45.state-management/deploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/45.state-management/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/45.state-management/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,184 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location of the Resource Group."
+            }
+        },
+        "groupName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Resource Group."
+            }
+        },
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "newAppServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan. Defaults to \"westus\"."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        }
+    },
+    "variables": {
+        "appServicePlanName": "[parameters('newAppServicePlanName')]",
+        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+    },
+    "resources": [
+        {
+            "name": "[parameters('groupName')]",
+            "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2018-05-01",
+            "location": "[parameters('groupLocation')]",
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "storageDeployment",
+            "resourceGroup": "[parameters('groupName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "comments": "Create a new App Service Plan",
+                            "type": "Microsoft.Web/serverfarms",
+                            "name": "[variables('appServicePlanName')]",
+                            "apiVersion": "2018-02-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "properties": {
+                                "name": "[variables('appServicePlanName')]"
+                            }
+                        },
+                        {
+                            "comments": "Create a Web App using the new App Service Plan",
+                            "type": "Microsoft.Web/sites",
+                            "apiVersion": "2015-08-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "kind": "app",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                            ],
+                            "name": "[variables('webAppName')]",
+                            "properties": {
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "siteConfig": {
+                                    "appSettings": [
+                                        {
+                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                            "value": "10.14.1"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppId",
+                                            "value": "[parameters('appId')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppPassword",
+                                            "value": "[parameters('appSecret')]"
+                                        }
+                                    ],
+                                    "cors": {
+                                        "allowedOrigins": [
+                                            "https://botservice.hosting.portal.azure.net",
+                                            "https://hosting.onecloud.azure-test.net/"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "apiVersion": "2021-03-01",
+                            "type": "Microsoft.BotService/botServices",
+                            "name": "[parameters('botId')]",
+                            "location": "global",
+                            "kind": "azurebot",
+                            "sku": {
+                                "name": "[parameters('botSku')]"
+                            },
+                            "properties": {
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
+                            },
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                            ]
+                        }
+                    ],
+                    "outputs": {}
+                }
+            }
+        }
+    ]
+}

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/deploymentTemplates/new-rg-parameters.json
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/deploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,184 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location of the Resource Group."
+            }
+        },
+        "groupName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Resource Group."
+            }
+        },
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "newAppServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan. Defaults to \"westus\"."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        }
+    },
+    "variables": {
+        "appServicePlanName": "[parameters('newAppServicePlanName')]",
+        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+    },
+    "resources": [
+        {
+            "name": "[parameters('groupName')]",
+            "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2018-05-01",
+            "location": "[parameters('groupLocation')]",
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "storageDeployment",
+            "resourceGroup": "[parameters('groupName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "comments": "Create a new App Service Plan",
+                            "type": "Microsoft.Web/serverfarms",
+                            "name": "[variables('appServicePlanName')]",
+                            "apiVersion": "2018-02-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "properties": {
+                                "name": "[variables('appServicePlanName')]"
+                            }
+                        },
+                        {
+                            "comments": "Create a Web App using the new App Service Plan",
+                            "type": "Microsoft.Web/sites",
+                            "apiVersion": "2015-08-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "kind": "app",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                            ],
+                            "name": "[variables('webAppName')]",
+                            "properties": {
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "siteConfig": {
+                                    "appSettings": [
+                                        {
+                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                            "value": "10.14.1"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppId",
+                                            "value": "[parameters('appId')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppPassword",
+                                            "value": "[parameters('appSecret')]"
+                                        }
+                                    ],
+                                    "cors": {
+                                        "allowedOrigins": [
+                                            "https://botservice.hosting.portal.azure.net",
+                                            "https://hosting.onecloud.azure-test.net/"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "apiVersion": "2021-03-01",
+                            "type": "Microsoft.BotService/botServices",
+                            "name": "[parameters('botId')]",
+                            "location": "global",
+                            "kind": "azurebot",
+                            "sku": {
+                                "name": "[parameters('botSku')]"
+                            },
+                            "properties": {
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
+                            },
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                            ]
+                        }
+                    ],
+                    "outputs": {}
+                }
+            }
+        }
+    ]
+}

--- a/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/deploymentTemplates/new-rg-parameters.json
+++ b/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/deploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,184 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location of the Resource Group."
+            }
+        },
+        "groupName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Resource Group."
+            }
+        },
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "newAppServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan. Defaults to \"westus\"."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        }
+    },
+    "variables": {
+        "appServicePlanName": "[parameters('newAppServicePlanName')]",
+        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+    },
+    "resources": [
+        {
+            "name": "[parameters('groupName')]",
+            "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2018-05-01",
+            "location": "[parameters('groupLocation')]",
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "storageDeployment",
+            "resourceGroup": "[parameters('groupName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "comments": "Create a new App Service Plan",
+                            "type": "Microsoft.Web/serverfarms",
+                            "name": "[variables('appServicePlanName')]",
+                            "apiVersion": "2018-02-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "properties": {
+                                "name": "[variables('appServicePlanName')]"
+                            }
+                        },
+                        {
+                            "comments": "Create a Web App using the new App Service Plan",
+                            "type": "Microsoft.Web/sites",
+                            "apiVersion": "2015-08-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "kind": "app",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                            ],
+                            "name": "[variables('webAppName')]",
+                            "properties": {
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "siteConfig": {
+                                    "appSettings": [
+                                        {
+                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                            "value": "10.14.1"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppId",
+                                            "value": "[parameters('appId')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppPassword",
+                                            "value": "[parameters('appSecret')]"
+                                        }
+                                    ],
+                                    "cors": {
+                                        "allowedOrigins": [
+                                            "https://botservice.hosting.portal.azure.net",
+                                            "https://hosting.onecloud.azure-test.net/"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "apiVersion": "2021-03-01",
+                            "type": "Microsoft.BotService/botServices",
+                            "name": "[parameters('botId')]",
+                            "location": "global",
+                            "kind": "azurebot",
+                            "sku": {
+                                "name": "[parameters('botSku')]"
+                            },
+                            "properties": {
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
+                            },
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                            ]
+                        }
+                    ],
+                    "outputs": {}
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Addresses # 3349

## Proposed Changes
This PR adds the bots' deployment templates (`template-with-new-rg.json`) under the [samples/javascript_nodejs](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/javascript_nodejs) folder using the new Azure Bot resource instead of the Bot Channel Registration.

### Detailed Changes
Added the ARM templates of the following samples:
- 14.nlp-with-orchestrator
- 23.facebook-events
- 43.complex-dialog
- 44.prompt-for-user-input
- 45.state-management
- language-generation/05.a.multi-turn-prompt-with-language-fallback
- language-generation/05.multi-turn-prompt

Bot that were not added:
- 01.console-echo => Console Bot
- 40.timex-resolution => Console Bot

## Testing
The following image shows two bots working with the new ARM Templates.
![imagen](https://user-images.githubusercontent.com/62260472/131393999-431f55d3-3e2f-433a-8c66-bfa732b2ebe4.png)
![imagen](https://user-images.githubusercontent.com/62260472/131394005-bbd14b85-3bae-4968-afe5-d7249b802bbd.png)
