### PR TITLE
[#3307] Migrate C# samples to Cloud Adapter - Adaptive-dialog folder

### DIFF
--- a/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/AdapterWithErrorHandler.cs
@@ -3,20 +3,20 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private Templates _templates;
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, IStorage storage,
-            UserState userState, ConversationState conversationState, IConfiguration configuration)
-            : base(credentialProvider)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, IStorage storage,
+            UserState userState, ConversationState conversationState)
+            : base(configuration, httpClientFactory, logger)
         {
             // These methods add middleware to the adapter. The middleware adds the storage and state objects to the
             // turn context each turn so that the dialog manager can retrieve them.

--- a/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Startup.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Startup.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
 
             // Register dialog. This sets up memory paths for adaptive.
             ComponentRegistration.Add(new DialogsComponentRegistration());

--- a/samples/csharp_dotnetcore/adaptive-dialog/02.using-cards/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/02.using-cards/AdapterWithErrorHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
@@ -11,12 +12,12 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private Templates _templates;
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, IStorage storage,
-            UserState userState, ConversationState conversationState, IConfiguration configuration)
-            : base(credentialProvider)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, IStorage storage,
+            UserState userState, ConversationState conversationState)
+            : base(configuration, httpClientFactory, logger)
         {
             this.UseStorage(storage);
             this.UseBotState(userState);

--- a/samples/csharp_dotnetcore/adaptive-dialog/02.using-cards/Startup.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/02.using-cards/Startup.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
@@ -19,7 +18,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
 
             // Register dialog. This sets up memory paths for adaptive.
             ComponentRegistration.Add(new DialogsComponentRegistration());

--- a/samples/csharp_dotnetcore/adaptive-dialog/03.core-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/03.core-bot/AdapterWithErrorHandler.cs
@@ -3,22 +3,20 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.Bot.Builder.Dialogs.Adaptive;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Generators;
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private Templates _templates;
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, IStorage storage,
-            UserState userState, ConversationState conversationState, IConfiguration configuration)
-            : base(credentialProvider)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, IStorage storage,
+            UserState userState, ConversationState conversationState)
+            : base(configuration, httpClientFactory, logger)
         {
             this.UseStorage(storage);
             this.UseBotState(userState);

--- a/samples/csharp_dotnetcore/adaptive-dialog/03.core-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/03.core-bot/Startup.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.AI.Luis;
 using Microsoft.Bot.Builder.Dialogs;
@@ -21,7 +20,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
 
             // Register dialog. This sets up memory paths for adaptive.
             ComponentRegistration.Add(new DialogsComponentRegistration());

--- a/samples/csharp_dotnetcore/adaptive-dialog/04.waterfall-or-custom-dialog-with-adaptive/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/04.waterfall-or-custom-dialog-with-adaptive/AdapterWithErrorHandler.cs
@@ -3,21 +3,21 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private Templates _templates;
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, IStorage storage,
-            UserState userState, ConversationState conversationState, IConfiguration configuration)
-            : base(credentialProvider)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, IStorage storage,
+            UserState userState, ConversationState conversationState)
+            : base(configuration, httpClientFactory, logger)
         {
             this.UseStorage(storage);
             this.UseBotState(userState);

--- a/samples/csharp_dotnetcore/adaptive-dialog/04.waterfall-or-custom-dialog-with-adaptive/Startup.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/04.waterfall-or-custom-dialog-with-adaptive/Startup.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -19,7 +18,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
 
             services.AddControllers().AddNewtonsoftJson();
 

--- a/samples/csharp_dotnetcore/adaptive-dialog/05.interruptions-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/05.interruptions-bot/AdapterWithErrorHandler.cs
@@ -3,20 +3,20 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private Templates _templates;
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, IStorage storage,
-            UserState userState, ConversationState conversationState, IConfiguration configuration)
-            : base(credentialProvider)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, IStorage storage,
+            UserState userState, ConversationState conversationState)
+            : base(configuration, httpClientFactory, logger)
         {
             this.UseStorage(storage);
             this.UseBotState(userState);

--- a/samples/csharp_dotnetcore/adaptive-dialog/05.interruptions-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/05.interruptions-bot/Startup.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.AI.Luis;
 using Microsoft.Bot.Builder.BotFramework;
@@ -29,7 +28,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
 
             // Register dialog. This sets up memory paths for adaptive.
             ComponentRegistration.Add(new DialogsComponentRegistration());

--- a/samples/csharp_dotnetcore/adaptive-dialog/06.todo-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/06.todo-bot/AdapterWithErrorHandler.cs
@@ -3,21 +3,21 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private Templates _templates;
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, IStorage storage,
-            UserState userState, ConversationState conversationState, IConfiguration configuration)
-            : base(credentialProvider)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, IStorage storage,
+            UserState userState, ConversationState conversationState)
+            : base(configuration, httpClientFactory, logger)
         {
             this.UseStorage(storage);
             this.UseBotState(userState);

--- a/samples/csharp_dotnetcore/adaptive-dialog/06.todo-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/06.todo-bot/Startup.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.AI.Luis;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,7 +20,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
 
             // Register dialog. This sets up memory paths for adaptive.
             ComponentRegistration.Add(new DialogsComponentRegistration());

--- a/samples/csharp_dotnetcore/adaptive-dialog/07.qnamaker/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/07.qnamaker/AdapterWithErrorHandler.cs
@@ -3,21 +3,21 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.LanguageGeneration;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private Templates _lgFile;
 
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, IStorage storage, UserState userState, ConversationState conversationState, IConfiguration configuration)
-            : base(credentialProvider, logger: logger)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, IStorage storage, UserState userState, ConversationState conversationState)
+            : base(configuration, httpClientFactory, logger)
         {
             this.Use(new RegisterClassMiddleware<IConfiguration>(configuration));
             this.UseStorage(storage);

--- a/samples/csharp_dotnetcore/adaptive-dialog/07.qnamaker/Startup.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/07.qnamaker/Startup.cs
@@ -3,12 +3,10 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.AI.QnA;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
-using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
@@ -29,7 +27,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
 
             // Register dialog. This sets up memory paths for adaptive.
             ComponentRegistration.Add(new DialogsComponentRegistration());

--- a/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/AdapterWithErrorHandler.cs
@@ -3,21 +3,21 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private Templates _templates;
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, IStorage storage,
-            UserState userState, ConversationState conversationState, IConfiguration configuration)
-            : base(credentialProvider)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, IStorage storage,
+            UserState userState, ConversationState conversationState)
+            : base(configuration, httpClientFactory, logger)
         {
             this.UseStorage(storage);
             this.UseBotState(userState);

--- a/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/Startup.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/Startup.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.AI.Luis;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,7 +20,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
 
             // Register dialog. This sets up memory paths for adaptive.
             ComponentRegistration.Add(new DialogsComponentRegistration());

--- a/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/AdapterWithErrorHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
@@ -10,10 +11,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState, UserState userState, IStorage storage)
-            : base(configuration, logger)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState, UserState userState, IStorage storage)
+            : base(configuration, httpClientFactory, logger)
         {
             this.Use(new RegisterClassMiddleware<IConfiguration>(configuration));
             this.UseStorage(storage);

--- a/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/Startup.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/Startup.cs
@@ -30,7 +30,7 @@ namespace Microsoft.BotBuilderSamples
         {
             services.AddMvc();
 
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
             // Required for memory paths introduced by adaptive dialogs.
             ComponentRegistration.Add(new DialogsComponentRegistration());

--- a/samples/csharp_dotnetcore/adaptive-dialog/20.EchoBot-declarative/EchoBotAdapter.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/20.EchoBot-declarative/EchoBotAdapter.cs
@@ -2,19 +2,19 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class EchoBotAdapter : BotFrameworkHttpAdapter
+    public class EchoBotAdapter : CloudAdapter
     {
-        public EchoBotAdapter(ICredentialProvider credentialProvider, IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger, IStorage storage, UserState userState, ConversationState conversationState, ResourceExplorer resourceExplorer)
-            : base(credentialProvider)
+        public EchoBotAdapter(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, IStorage storage, UserState userState, ConversationState conversationState, ResourceExplorer resourceExplorer)
+            : base(configuration, httpClientFactory, logger)
         {
             this.Use(new RegisterClassMiddleware<IConfiguration>(configuration));
             this.UseStorage(storage);

--- a/samples/csharp_dotnetcore/adaptive-dialog/20.EchoBot-declarative/Startup.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/20.EchoBot-declarative/Startup.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Dialogs;
@@ -12,7 +11,6 @@ using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -30,7 +28,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
 
             // Register dialog. This sets up memory paths for adaptive.
             ComponentRegistration.Add(new DialogsComponentRegistration());

--- a/samples/csharp_dotnetcore/adaptive-dialog/21.AdaptiveBot-declarative/AdaptiveBotHttpAdapter.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/21.AdaptiveBot-declarative/AdaptiveBotHttpAdapter.cs
@@ -2,21 +2,21 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdaptiveBotHttpAdapter : BotFrameworkHttpAdapter
+    public class AdaptiveBotHttpAdapter : CloudAdapter
     {
-        public AdaptiveBotHttpAdapter(ICredentialProvider credentialProvider,
-            IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger,
-            IStorage storage, UserState userState, ConversationState conversationState, ResourceExplorer resourceExplorer)
-            : base(credentialProvider)
+        public AdaptiveBotHttpAdapter(IConfiguration configuration,
+            IHttpClientFactory httpClientFactory,
+            ILogger<IBotFrameworkHttpAdapter> logger,
+            IStorage storage, UserState userState, ConversationState conversationState)
+            : base(configuration, httpClientFactory, logger)
         {
             this.Use(new RegisterClassMiddleware<IConfiguration>(configuration));
             this.UseStorage(storage);

--- a/samples/csharp_dotnetcore/adaptive-dialog/21.AdaptiveBot-declarative/Startup.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/21.AdaptiveBot-declarative/Startup.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Dialogs;
@@ -12,7 +11,6 @@ using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -30,7 +28,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
 
             // Register dialog. This sets up memory paths for adaptive.
             ComponentRegistration.Add(new DialogsComponentRegistration());


### PR DESCRIPTION
Fixes # 3307

## Description
This PR migrates the remaining C# bots in the samples/adaptive-dialog folder from _BotFrameworkAdapter_ to _CloudAdapter_.

### Detailed Changes
Updated the following samples to use Cloud Adapter:
- 01.multi-turn-prompt
- 02.using-cards
- 03.core-bot
- 04.waterfall-or-custom-dialog-with-adaptive
- 05.interruptions-bot
- 06.todo-bot
- 07.qnamaker
- 08.todo-bot-luis-qnamaker
- 09.integrating-composer-dialogs
- 20.EchoBot-declarative
- 21.AdaptiveBot-declarative

## Testing
These images show some of the migrated bots working as expected.
![image](https://user-images.githubusercontent.com/44245136/133831253-aad0590d-db26-4204-bd71-f809c63a6c7a.png)
