### PR TITLE
[#3307] Migrate C# samples to Cloud Adapter - Language-Generation folder

### DIFF
--- a/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/AdapterWithErrorHandler.cs
@@ -3,22 +3,23 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Extensions.Logging;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using System.Collections.Generic;
 using Microsoft.Bot.Builder.LanguageGeneration;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private MultiLanguageLG _lgManager;
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
-            : base(credentialProvider)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
+            : base(configuration, httpClientFactory, logger)
         {
-            Dictionary<string, string> lgFilesPerLocale = new Dictionary<string, string>() 
+            Dictionary<string, string> lgFilesPerLocale = new Dictionary<string, string>()
             {
                 {"", Path.Combine(".", "Resources", "AdapterWithErrorHandler.lg")},
                 {"fr", Path.Combine(".", "Resources", "AdapterWithErrorHandler.fr-fr.lg")}

--- a/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Startup.cs
+++ b/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Startup.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
@@ -17,7 +16,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
             
             // Create the credential provider to be used with the Bot Framework Adapter.
             services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();

--- a/samples/csharp_dotnetcore/language-generation/05.multi-turn-prompt/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/language-generation/05.multi-turn-prompt/AdapterWithErrorHandler.cs
@@ -3,20 +3,21 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Extensions.Logging;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private Templates _templates;
 
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
-            : base(credentialProvider)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
+            : base(configuration, httpClientFactory, logger)
         {
             // combine path for cross platform support
             string[] paths = { ".", "Resources", "AdapterWithErrorHandler.lg" };

--- a/samples/csharp_dotnetcore/language-generation/05.multi-turn-prompt/Startup.cs
+++ b/samples/csharp_dotnetcore/language-generation/05.multi-turn-prompt/Startup.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
@@ -18,7 +17,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
             
             // Create the credential provider to be used with the Bot Framework Adapter.
             services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();

--- a/samples/csharp_dotnetcore/language-generation/06.using-cards/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/language-generation/06.using-cards/AdapterWithErrorHandler.cs
@@ -3,19 +3,22 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Extensions.Logging;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Extensions.Configuration;
+
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private Templates _templates;
 
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
-            : base(credentialProvider)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
+            : base(configuration, httpClientFactory, logger)
         {
             // combine path for cross platform support
             string[] paths = { ".", "Resources", "AdapterWithErrorHandler.lg" };

--- a/samples/csharp_dotnetcore/language-generation/06.using-cards/Startup.cs
+++ b/samples/csharp_dotnetcore/language-generation/06.using-cards/Startup.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
@@ -18,7 +17,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
             
             // Create the credential provider to be used with the Bot Framework Adapter.
             services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();

--- a/samples/csharp_dotnetcore/language-generation/13.core-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/language-generation/13.core-bot/AdapterWithErrorHandler.cs
@@ -3,19 +3,21 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Extensions.Logging;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Extensions.Configuration;
+
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private Templates _templates;
 
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
-            : base(credentialProvider)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
+            : base(configuration, httpClientFactory, logger)
         {
             // combine path for cross platform support
             string[] paths = { ".", "Resources", "AdapterWithErrorHandler.lg" };

--- a/samples/csharp_dotnetcore/language-generation/13.core-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/language-generation/13.core-bot/Startup.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
@@ -24,7 +23,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddHttpClient().AddMvc();
 
             // Create the credential provider to be used with the Bot Framework Adapter.
             services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();

--- a/samples/csharp_dotnetcore/language-generation/20.extending-with-custom-functions/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/language-generation/20.extending-with-custom-functions/AdapterWithErrorHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Extensions.Configuration;
@@ -8,10 +9,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger)
-            : base(configuration, logger)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(configuration, httpClientFactory, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/language-generation/20.extending-with-custom-functions/Startup.cs
+++ b/samples/csharp_dotnetcore/language-generation/20.extending-with-custom-functions/Startup.cs
@@ -25,7 +25,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
             // Create the Bot Framework Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();

--- a/samples/csharp_webapi/13.core-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_webapi/13.core-bot/AdapterWithErrorHandler.cs
@@ -3,20 +3,18 @@
 
 using System;
 using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.WebApi;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
-            : base(credentialProvider: credentialProvider, logger: logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication botFrameworkAuthentication, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
+            : base(botFrameworkAuthentication, logger: logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_webapi/13.core-bot/Controllers/BotController.cs
+++ b/samples/csharp_webapi/13.core-bot/Controllers/BotController.cs
@@ -8,7 +8,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.WebApi;
 using Microsoft.BotBuilderSamples.Bots;
 using Microsoft.BotBuilderSamples.Dialogs;
@@ -39,8 +38,8 @@ namespace Microsoft.BotBuilderSamples
             _userState = new UserState(storage);
             
             // create the BotAdapter we will be using
-            var credentialProvider = new ConfigurationCredentialProvider();
-            _adapter = new AdapterWithErrorHandler(credentialProvider, _loggerFactory.CreateLogger<BotFrameworkHttpAdapter>(), _conversationState);
+            var botFrameworkAuthentication = new ConfigurationBotFrameworkAuthentication();
+            _adapter = new AdapterWithErrorHandler(botFrameworkAuthentication, _loggerFactory.CreateLogger<IBotFrameworkHttpAdapter>(), _conversationState);
 
             // read the old style Web.Config settings and construct a new style dot net core IConfiguration object
             var appsettings = ConfigurationManager.AppSettings.AllKeys.SelectMany(


### PR DESCRIPTION
Fixes # 3307

## Description
This PR migrates the remaining C# bots in the samples/language-generation folder from _BotFrameworkAdapter_ to _CloudAdapter_.

### Detailed Changes
Updated the following samples to use Cloud Adapter:
- 05.a.multi-turn-prompt-with-language-fallback
- 05.multi-turn-prompt
- 06.using-cards
- 13.core-bot
- 20.extending-with-custom-functions
- csharp_webapi/13.core-bot

## Testing
These images show some of the migrated bots working as expected.
![image](https://user-images.githubusercontent.com/44245136/133832057-a5cea9e4-1483-40e0-8906-89ef5ee3577f.png)
