### PR TITLE
[#3499] Migrate JS samples and generators to Cloud Adapter - samples folder - fourth batch

### DIFF
--- a/samples/javascript_nodejs/56.teams-file-upload/index.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/index.js
@@ -14,21 +14,29 @@ const restify = require('restify');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const { BotFrameworkAdapter } = require('botbuilder');
+const {
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration
+} = require('botbuilder');
 
 const { TeamsFileUploadBot } = require('./bots/teamsFileUploadBot');
 
-// Create adapter.
-// See https://aka.ms/about-bot-adapter to learn more about adapters.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword
 });
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
+// Create adapter.
+// See https://aka.ms/about-bot-adapter to learn more about how bots work.
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       application insights. See https://aka.ms/bottelemetry for telemetry
     //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
@@ -49,13 +57,14 @@ const bot = new TeamsFileUploadBot();
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }`);
 });
 
 // Listen for incoming requests.
-server.post('/api/messages', (req, res) => {
-    adapter.processActivity(req, res, async (context) => {
-        await bot.run(context);
-    });
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => bot.run(context));
 });

--- a/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
@@ -16,7 +16,7 @@ const geneFileName = async (fileDir) => {
 // Download and Save Streams into File
 const writeFile = async (contentUrl, config, filePath) => {
     const response = await axios({ method: 'GET', url: contentUrl, responseType: 'stream' });
-    return await new Promise((resolve, reject) => response.pipe(fs.createWriteStream(filePath)).once('finish', resolve).once('error', reject));    
+    return await new Promise((resolve, reject) => response.data.pipe(fs.createWriteStream(filePath)).once('finish', resolve).once('error', reject));
 };
 
 // Returns File Size

--- a/samples/javascript_nodejs/57.teams-conversation-bot/index.js
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/index.js
@@ -14,21 +14,29 @@ const restify = require('restify');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const { BotFrameworkAdapter } = require('botbuilder');
+const {
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration
+} = require('botbuilder');
 
 const { TeamsConversationBot } = require('./bots/teamsConversationBot');
 
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
-});
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       application insights. See https://aka.ms/bottelemetry for telemetry
     //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
@@ -50,13 +58,14 @@ const bot = new TeamsConversationBot();
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }`);
 });
 
 // Listen for incoming requests.
-server.post('/api/messages', (req, res) => {
-    adapter.processActivity(req, res, async (context) => {
-        await bot.run(context);
-    });
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => bot.run(context));
 });

--- a/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/bots/teamsStartNewThreadInChannel.js
+++ b/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/bots/teamsStartNewThreadInChannel.js
@@ -17,10 +17,9 @@ class TeamsStartNewThreadInChannel extends TeamsActivityHandler {
             const message = MessageFactory.text('This will be the first message in a new thread');
             const newConversation = await this.teamsCreateConversation(context, teamsChannelId, message);
 
-            await context.adapter.continueConversation(newConversation[0],
-                async (t) => {
-                    await t.sendActivity(MessageFactory.text('This will be the first response to the new thread'));
-                });
+            await context.adapter.continueConversationAsync(process.env.MicrosoftAppId, newConversation[0], async turnContext => {
+                await turnContext.sendActivity(MessageFactory.text('This will be the first response to the new thread'));
+            });
 
             await next();
         });
@@ -38,7 +37,9 @@ class TeamsStartNewThreadInChannel extends TeamsActivityHandler {
             activity: message
         };
 
-        const connectorClient = context.adapter.createConnectorClient(context.activity.serviceUrl);
+        const connectorFactory = context.turnState.get(context.adapter.ConnectorFactoryKey);
+        const connectorClient = await connectorFactory.create(context.activity.serviceUrl);
+
         const conversationResourceResponse = await connectorClient.conversations.createConversation(conversationParameters);
         const conversationReference = TurnContext.getConversationReference(context.activity);
         conversationReference.conversation.id = conversationResourceResponse.id;

--- a/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/index.js
+++ b/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/index.js
@@ -14,21 +14,29 @@ const restify = require('restify');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const { BotFrameworkAdapter } = require('botbuilder');
+const {
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration
+} = require('botbuilder');
 
 const { TeamsStartNewThreadInChannel } = require('./bots/TeamsStartNewThreadInChannel');
 
-// Create adapter.
-// See https://aka.ms/about-bot-adapter to learn more about adapters.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword
 });
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
+// Create adapter.
+// See https://aka.ms/about-bot-adapter to learn more about how bots work.
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       application insights. See https://aka.ms/bottelemetry for telemetry
     //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
@@ -50,13 +58,14 @@ const bot = new TeamsStartNewThreadInChannel();
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }`);
 });
 
 // Listen for incoming requests.
-server.post('/api/messages', (req, res) => {
-    adapter.processActivity(req, res, async (context) => {
-        await bot.run(context);
-    });
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => bot.run(context));
 });


### PR DESCRIPTION
Addresses # 3499

## Description
This PR updates the last 3 bots in the samples folder to use **_Cloud Adapter_** instead of **_BotFrameworkAdapter_**. 

### Detailed Changes
Updated the following bots:
- 56.teams-file-upload
- 57.teams-conversation-bot
- 58.teams-start-new-thread-in-channel

## Testing
This image shows the teams-conversation-bot working with Cloud Adapter.
![image](https://user-images.githubusercontent.com/44245136/136046357-6efc359f-c230-4fdd-9d1f-465a3b98fce3.png)
