### PR TITLE
[#3499] Migrate JS samples and generators to Cloud Adapter - language-generation folder

### DIFF
--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/dialogs/userProfileDialog.js
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/dialogs/userProfileDialog.js
@@ -48,8 +48,8 @@ class UserProfileDialog extends ComponentDialog {
 
         // Define per locale LG files.
         const templatesPerLocale = new Map();
-        templatesPerLocale.set('', Templates.parseFile(`${__dirname}/../Resources/UserProfileDialog.lg`)),
-        templatesPerLocale.set('fr', Templates.parseFile(`${__dirname}/../Resources/UserProfileDialog.fr-fr.lg`));
+        templatesPerLocale.set('', Templates.parseFile(`${ __dirname }/../Resources/UserProfileDialog.lg`));
+        templatesPerLocale.set('fr', Templates.parseFile(`${ __dirname }/../Resources/UserProfileDialog.fr-fr.lg`));
         this.lgTemplates = new MultiLanguageLG(templatesPerLocale);
     }
 

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/dialogs/userProfileDialog.js
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/dialogs/userProfileDialog.js
@@ -48,8 +48,8 @@ class UserProfileDialog extends ComponentDialog {
 
         // Define per locale LG files.
         const templatesPerLocale = new Map();
-        templatesPerLocale.set('', Templates.parseFile(`${ __dirname }/../Resources/UserProfileDialog.lg`));
-        templatesPerLocale.set('fr', Templates.parseFile(`${ __dirname }/../Resources/UserProfileDialog.fr-fr.lg`));
+        templatesPerLocale.set('', Templates.parseFile(`${__dirname}/../Resources/UserProfileDialog.lg`)),
+        templatesPerLocale.set('fr', Templates.parseFile(`${__dirname}/../Resources/UserProfileDialog.fr-fr.lg`));
         this.lgTemplates = new MultiLanguageLG(templatesPerLocale);
     }
 

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
@@ -13,9 +13,9 @@ const { Templates, MultiLanguageLG } = require('botbuilder-lg');
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
 const {
-    createBotFrameworkAuthenticationFromConfiguration,
     CloudAdapter,
     ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration,
     ConversationState,
     MemoryStorage,
     UserState
@@ -38,8 +38,8 @@ const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Create template engine for language generation.
 const templatesPerLocale = new Map();
-templatesPerLocale.set('', Templates.parseFile(`${ __dirname }/Resources/adapterWithErrorHandler.lg`));
-templatesPerLocale.set('fr', Templates.parseFile(`${ __dirname }/Resources/adapterWithErrorHandler.fr-fr.lg`));
+templatesPerLocale.set('', Templates.parseFile(`${__dirname}/Resources/adapterWithErrorHandler.lg`)),
+templatesPerLocale.set('fr', Templates.parseFile(`${__dirname}/Resources/adapterWithErrorHandler.fr-fr.lg`));
 const multiLangLG = new MultiLanguageLG(templatesPerLocale);
 
 // Catch-all for errors.
@@ -94,5 +94,5 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 // Listen for incoming requests.
 server.post('/api/messages', async (req, res) => {
     // Route received a request to adapter for processing
-    await adapter.process(req, res, (turnContext) => bot.run(turnContext));
+    await adapter.process(req, res, (context) => bot.run(context));
 });

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
@@ -46,7 +46,7 @@ const multiLangLG = new MultiLanguageLG(templatesPerLocale);
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       application insights. See https://aka.ms/bottelemetry for telemetry
     //       configuration instructions.
     const langResponse = multiLangLG.generate('SomethingWentWrong', {
         message: `${ error }`

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
@@ -15,8 +15,8 @@ const { Templates, MultiLanguageLG } = require('botbuilder-lg');
 const {
     CloudAdapter,
     ConfigurationServiceClientCredentialFactory,
-    createBotFrameworkAuthenticationFromConfiguration,
     ConversationState,
+    createBotFrameworkAuthenticationFromConfiguration,
     MemoryStorage,
     UserState
 } = require('botbuilder');

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
@@ -12,23 +12,34 @@ const { Templates, MultiLanguageLG } = require('botbuilder-lg');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState, ActivityFactory } = require('botbuilder');
+const {
+    createBotFrameworkAuthenticationFromConfiguration,
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    ConversationState,
+    MemoryStorage,
+    UserState
+} = require('botbuilder');
 
 // Import our custom bot class that provides a turn handling function.
 const { DialogBot } = require('./bots/dialogBot');
 const { UserProfileDialog } = require('./dialogs/userProfileDialog');
 
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
 // Create the adapter. See https://aka.ms/about-bot-adapter to learn more about using information from
 // the .bot file when configuring your adapter.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
-});
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Create template engine for language generation.
 const templatesPerLocale = new Map();
-templatesPerLocale.set('', Templates.parseFile(`${__dirname}/Resources/adapterWithErrorHandler.lg`)),
-templatesPerLocale.set('fr', Templates.parseFile(`${__dirname}/Resources/adapterWithErrorHandler.fr-fr.lg`));
+templatesPerLocale.set('', Templates.parseFile(`${ __dirname }/Resources/adapterWithErrorHandler.lg`));
+templatesPerLocale.set('fr', Templates.parseFile(`${ __dirname }/Resources/adapterWithErrorHandler.fr-fr.lg`));
 const multiLangLG = new MultiLanguageLG(templatesPerLocale);
 
 // Catch-all for errors.
@@ -37,7 +48,7 @@ adapter.onTurnError = async (context, error) => {
     // NOTE: In production environment, you should consider logging this to Azure
     //       application insights. See https://aka.ms/bottelemetry for telemetry 
     //       configuration instructions.
-    let langResponse = multiLangLG.generate('SomethingWentWrong', {
+    const langResponse = multiLangLG.generate('SomethingWentWrong', {
         message: `${ error }`
     }, context.activity.locale);
     console.error(langResponse);
@@ -72,6 +83,8 @@ const bot = new DialogBot(conversationState, userState, dialog);
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }.`);
     console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
@@ -79,9 +92,7 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 });
 
 // Listen for incoming requests.
-server.post('/api/messages', (req, res) => {
-    adapter.processActivity(req, res, async (context) => {
-        // Route the message to the bot's main handler.
-        await bot.run(context);
-    });
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (turnContext) => bot.run(turnContext));
 });

--- a/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
+++ b/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
@@ -12,18 +12,29 @@ const { Templates } = require('botbuilder-lg');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState } = require('botbuilder');
+const {
+    createBotFrameworkAuthenticationFromConfiguration,
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    ConversationState,
+    MemoryStorage,
+    UserState
+} = require('botbuilder');
 
 // Import our custom bot class that provides a turn handling function.
 const { DialogBot } = require('./bots/dialogBot');
 const { UserProfileDialog } = require('./dialogs/userProfileDialog');
 
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
 // Create the adapter. See https://aka.ms/about-bot-adapter to learn more about using information from
 // the .bot file when configuring your adapter.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
-});
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Create template engine for language generation.
 const lgTemplates = Templates.parseFile('./Resources/AdapterWithErrorHandler.lg');
@@ -32,7 +43,7 @@ const lgTemplates = Templates.parseFile('./Resources/AdapterWithErrorHandler.lg'
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       application insights. See https://aka.ms/bottelemetry for telemetry
     //       configuration instructions.
     console.error(lgTemplates.evaluate('SomethingWentWrong', {
         message: `${ error }`
@@ -68,6 +79,8 @@ const bot = new DialogBot(conversationState, userState, dialog);
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }.`);
     console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
@@ -75,9 +88,7 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 });
 
 // Listen for incoming requests.
-server.post('/api/messages', (req, res) => {
-    adapter.processActivity(req, res, async (context) => {
-        // Route the message to the bot's main handler.
-        await bot.run(context);
-    });
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (turnContext) => bot.run(turnContext));
 });

--- a/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
+++ b/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
@@ -13,9 +13,9 @@ const { Templates } = require('botbuilder-lg');
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
 const {
-    createBotFrameworkAuthenticationFromConfiguration,
     CloudAdapter,
     ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration,
     ConversationState,
     MemoryStorage,
     UserState
@@ -90,5 +90,5 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 // Listen for incoming requests.
 server.post('/api/messages', async (req, res) => {
     // Route received a request to adapter for processing
-    await adapter.process(req, res, (turnContext) => bot.run(turnContext));
+    await adapter.process(req, res, (context) => bot.run(context));
 });

--- a/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
+++ b/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
@@ -15,8 +15,8 @@ const { Templates } = require('botbuilder-lg');
 const {
     CloudAdapter,
     ConfigurationServiceClientCredentialFactory,
-    createBotFrameworkAuthenticationFromConfiguration,
     ConversationState,
+    createBotFrameworkAuthenticationFromConfiguration,
     MemoryStorage,
     UserState
 } = require('botbuilder');

--- a/samples/javascript_nodejs/language-generation/06.using-cards/index.js
+++ b/samples/javascript_nodejs/language-generation/06.using-cards/index.js
@@ -14,9 +14,9 @@ const { Templates } = require('botbuilder-lg');
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
 const {
-    createBotFrameworkAuthenticationFromConfiguration,
     CloudAdapter,
     ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration,
     ConversationState,
     MemoryStorage,
     UserState
@@ -91,5 +91,5 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 // Listen for incoming activities and route them to your bot main dialog.
 server.post('/api/messages', async (req, res) => {
     // Route received a request to adapter for processing
-    await adapter.process(req, res, (turnContext) => bot.run(turnContext));
+    await adapter.process(req, res, (context) => bot.run(context));
 });

--- a/samples/javascript_nodejs/language-generation/06.using-cards/index.js
+++ b/samples/javascript_nodejs/language-generation/06.using-cards/index.js
@@ -13,17 +13,28 @@ const { Templates } = require('botbuilder-lg');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const { BotFrameworkAdapter, MemoryStorage, ConversationState, UserState } = require('botbuilder');
+const {
+    createBotFrameworkAuthenticationFromConfiguration,
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    ConversationState,
+    MemoryStorage,
+    UserState
+} = require('botbuilder');
 
 // This bot's main dialog.
 const { RichCardsBot } = require('./bots/richCardsBot');
 const { MainDialog } = require('./dialogs/mainDialog');
 
-// Create adapter. See https://aka.ms/about-bot-adapter to learn more about adapters.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword
 });
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
+// Create adapter. See https://aka.ms/about-bot-adapter to learn more about adapters.
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Create template engine for language generation.
 const lgTemplates = Templates.parseFile('./resources/AdapterWithErrorHandler.lg');
@@ -32,7 +43,7 @@ const lgTemplates = Templates.parseFile('./resources/AdapterWithErrorHandler.lg'
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       application insights. See https://aka.ms/bottelemetry for telemetry
     //       configuration instructions.
     console.error(lgTemplates.evaluate('SomethingWentWrong', {
         message: `${ error }`
@@ -69,6 +80,8 @@ const bot = new RichCardsBot(conversationState, userState, dialog);
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }.`);
     console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
@@ -76,10 +89,7 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 });
 
 // Listen for incoming activities and route them to your bot main dialog.
-server.post('/api/messages', (req, res) => {
+server.post('/api/messages', async (req, res) => {
     // Route received a request to adapter for processing
-    adapter.processActivity(req, res, async (turnContext) => {
-        // route to bot activity handler.
-        await bot.run(turnContext);
-    });
+    await adapter.process(req, res, (turnContext) => bot.run(turnContext));
 });

--- a/samples/javascript_nodejs/language-generation/06.using-cards/index.js
+++ b/samples/javascript_nodejs/language-generation/06.using-cards/index.js
@@ -16,8 +16,8 @@ const { Templates } = require('botbuilder-lg');
 const {
     CloudAdapter,
     ConfigurationServiceClientCredentialFactory,
-    createBotFrameworkAuthenticationFromConfiguration,
     ConversationState,
+    createBotFrameworkAuthenticationFromConfiguration,
     MemoryStorage,
     UserState
 } = require('botbuilder');

--- a/samples/javascript_nodejs/language-generation/13.core-bot/index.js
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/index.js
@@ -15,7 +15,15 @@ const { Templates } = require('botbuilder-lg');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const { BotFrameworkAdapter, ConversationState, InputHints, MemoryStorage, UserState } = require('botbuilder');
+const {
+    createBotFrameworkAuthenticationFromConfiguration,
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    ConversationState,
+    InputHints,
+    MemoryStorage,
+    UserState
+} = require('botbuilder');
 
 const { FlightBookingRecognizer } = require('./dialogs/flightBookingRecognizer');
 
@@ -27,12 +35,16 @@ const { MainDialog } = require('./dialogs/mainDialog');
 const { BookingDialog } = require('./dialogs/bookingDialog');
 const BOOKING_DIALOG = 'bookingDialog';
 
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
-});
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Create template engine for language generation.
 console.log(path.join(__dirname, './resources/AdapterWithErrorHandler.lg'));
@@ -42,7 +54,7 @@ const lgTemplates = Templates.parseFile(path.join(__dirname, './resources/Adapte
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       application insights. See https://aka.ms/bottelemetry for telemetry
     //       configuration instructions.
     console.error(lgTemplates.evaluate('SomethingWentWrong', {
         message: `${ error }`
@@ -88,6 +100,8 @@ const bot = new DialogAndWelcomeBot(conversationState, userState, dialog);
 
 // Create HTTP server
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }`);
     console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
@@ -95,10 +109,7 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 });
 
 // Listen for incoming activities and route them to your bot main dialog.
-server.post('/api/messages', (req, res) => {
+server.post('/api/messages', async (req, res) => {
     // Route received a request to adapter for processing
-    adapter.processActivity(req, res, async (turnContext) => {
-        // route to bot activity handler.
-        await bot.run(turnContext);
-    });
+    await adapter.process(req, res, (turnContext) => bot.run(turnContext));
 });

--- a/samples/javascript_nodejs/language-generation/13.core-bot/index.js
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/index.js
@@ -18,8 +18,8 @@ const { Templates } = require('botbuilder-lg');
 const {
     CloudAdapter,
     ConfigurationServiceClientCredentialFactory,
-    createBotFrameworkAuthenticationFromConfiguration,
     ConversationState,
+    createBotFrameworkAuthenticationFromConfiguration,
     InputHints,
     MemoryStorage,
     UserState

--- a/samples/javascript_nodejs/language-generation/13.core-bot/index.js
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/index.js
@@ -16,9 +16,9 @@ const { Templates } = require('botbuilder-lg');
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
 const {
-    createBotFrameworkAuthenticationFromConfiguration,
     CloudAdapter,
     ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration,
     ConversationState,
     InputHints,
     MemoryStorage,
@@ -111,5 +111,5 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 // Listen for incoming activities and route them to your bot main dialog.
 server.post('/api/messages', async (req, res) => {
     // Route received a request to adapter for processing
-    await adapter.process(req, res, (turnContext) => bot.run(turnContext));
+    await adapter.process(req, res, (context) => bot.run(context));
 });

--- a/samples/javascript_nodejs/language-generation/20.custom-functions/index.js
+++ b/samples/javascript_nodejs/language-generation/20.custom-functions/index.js
@@ -14,9 +14,9 @@ const { Templates } = require('botbuilder-lg');
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
 const {
-    createBotFrameworkAuthenticationFromConfiguration,
     CloudAdapter,
-    ConfigurationServiceClientCredentialFactory
+    ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration,
 } = require('botbuilder');
 
 // This bot's main dialog.
@@ -77,7 +77,7 @@ const myBot = new EchoBot();
 // Listen for incoming requests.
 server.post('/api/messages', async (req, res) => {
     // Route received a request to adapter for processing
-    await adapter.process(req, res, (turnContext) => myBot.run(turnContext));
+    await adapter.process(req, res, (context) => myBot.run(context));
 });
 
 // Listen for Upgrade requests for Streaming.
@@ -88,9 +88,5 @@ server.on('upgrade', async (req, socket, head) => {
     // Set onTurnError for the CloudAdapter created for each connection.
     streamingAdapter.onTurnError = onTurnErrorHandler;
 
-    streamingAdapter.useWebSocket(req, socket, head, async (context) => {
-        // After connecting via WebSocket, run this logic for every request sent over
-        // the WebSocket connection.
-        await myBot.run(context);
-    });
+    await streamingAdapter.process(req, socket, head, (context) => bot.run(context));
 });


### PR DESCRIPTION
Addresses # 3499

## Description
This PR updates the generators' template bots to use Cloud Adapter instead of BotFrameworkAdapter. 
It includes JavaScript templates.

### Detailed Changes
Updated the following bots' templates:
- 05.a.multi-turn-prompt-with-language-fallback
- 05.multi-turn-prompt
- 06.using-cards
- 13.core-bot
- 20.custom-functions

## Testing
These images show the JS bots working with CloudAdapter.

05.a.multi-turn-prompt-with-language-fallback
![image](https://user-images.githubusercontent.com/18757147/136057381-72c4bae9-25ba-4045-9659-d19aca215064.png)

05.multi-turn-prompt
![image](https://user-images.githubusercontent.com/18757147/136057423-2cc9fd68-3465-4b60-94cc-ced8250f0f52.png)

06.using-cards
![image](https://user-images.githubusercontent.com/18757147/136057467-55dab0d3-24cf-4ac4-9592-f22b34f4ad57.png)

13.core-bot
![image](https://user-images.githubusercontent.com/18757147/136057496-19e028f0-b084-48d2-9230-3dcffcbf84db.png)

20.custom-functions
![image](https://user-images.githubusercontent.com/18757147/136057564-f22c9a1c-173b-4f5d-a7e3-52cf3080aa49.png)


