### PR TITLE
[#3503] Add support for MSI to DotNet's samples and generators - qna maker samples

### DIFF
--- a/samples/csharp_dotnetcore/11.qnamaker/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/11.qnamaker/AdapterWithErrorHandler.cs
@@ -2,19 +2,18 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/11.qnamaker/QnABot.csproj
+++ b/samples/csharp_dotnetcore/11.qnamaker/QnABot.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.14.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/11.qnamaker/Startup.cs
+++ b/samples/csharp_dotnetcore/11.qnamaker/Startup.cs
@@ -4,7 +4,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,10 +21,10 @@ namespace Microsoft.BotBuilderSamples
             // Add the HttpClientFactory to be used for the QnAMaker calls.
             services.AddHttpClient();
 
-            // Create the credential provider to be used with the Bot Framework Adapter.
-            services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
 
-            // Create the Bot Framework Adapter with error handling enabled. 
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.

--- a/samples/csharp_dotnetcore/11.qnamaker/appsettings.json
+++ b/samples/csharp_dotnetcore/11.qnamaker/appsettings.json
@@ -1,6 +1,8 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": "",
   "QnAKnowledgebaseId": "",
   "QnAEndpointKey": "",
   "QnAEndpointHostName": ""

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/AdapterWithErrorHandler.cs
@@ -2,19 +2,18 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/QnABotAllFeatures.csproj
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/QnABotAllFeatures.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.14.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.14.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
 
     <ItemGroup>

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/Startup.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.BotBuilderSamples.Bots;
 using Microsoft.BotBuilderSamples.Dialog;
 using Microsoft.Extensions.Configuration;
@@ -28,7 +29,10 @@ namespace Microsoft.BotBuilderSamples
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the bot services(QnA) as a singleton.

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/appsettings.json
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/appsettings.json
@@ -1,8 +1,10 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": "",
   "QnAKnowledgebaseId": "",
   "QnAEndpointKey": "",
   "QnAEndpointHostName": "",
-  "DefaultAnswer": "" 
+  "DefaultAnswer": ""
 }


### PR DESCRIPTION
Addresses # 3503

> **Note:** The pipeline `Samples-CI-PR-Pipelines-Runner` is failing due to not finding the `4.15.0-daily.20211006.271232.c20cc39` version in NuGet, whereas this is only available in Artifacts or MyGet.

> **Note:** Currently, MSI and SingleTenant support needs the version `4.15.x` that's under development, therefore these PR changes will use the `4.15.0-daily.20211006.271232.c20cc39` version instead. Once the `4.15.x` version is released, this will be updated.

## Description
This PR updates the QnA Maker bots' samples, adding support for MSI and SingleTenant App types.

### Detailed Changes
- Updated **_AdapterWithErrorHandler_** class to receive the _BotFrameworkAuthentication_ in the constructor.
- Updated the **_Microsoft.Bot.Builder.Integration.AspNet.Core_** dependency to the latest preview version.
- Updated **_Startup_** class to create the _BotFrameworkAuthentication_.
- Added the new settings _MicrosoftAppType_ and _MicrosoftAppTenantId_ to the **_appsettings.json_** file.

This PR updates the following samples:
- 11.qnamaker
- 49.qnamaker-all-features

## Testing
The following images show the `11.qnamaker` and `49.qnamaker-all-features` bots working with the three app types: MultiTenant, SingleTenant, and MSI.
![imagen](https://user-images.githubusercontent.com/62260472/137513151-bd0236f7-f93e-440c-a2ac-2e31501b549f.png)