### PR TITLE
[#3526] Add support for MSI to JS samples and generators - language-generation samples

### DIFF
--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/.env
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
@@ -12,18 +12,29 @@ const { Templates, MultiLanguageLG } = require('botbuilder-lg');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState, ActivityFactory } = require('botbuilder');
+const {
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    ConversationState,
+    createBotFrameworkAuthenticationFromConfiguration,
+    MemoryStorage,
+    UserState
+} = require('botbuilder');
 
 // Import our custom bot class that provides a turn handling function.
 const { DialogBot } = require('./bots/dialogBot');
 const { UserProfileDialog } = require('./dialogs/userProfileDialog');
 
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
 // Create the adapter. See https://aka.ms/about-bot-adapter to learn more about using information from
 // the .bot file when configuring your adapter.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
-});
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Create template engine for language generation.
 const templatesPerLocale = new Map();
@@ -35,9 +46,9 @@ const multiLangLG = new MultiLanguageLG(templatesPerLocale);
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       application insights. See https://aka.ms/bottelemetry for telemetry
     //       configuration instructions.
-    let langResponse = multiLangLG.generate('SomethingWentWrong', {
+    const langResponse = multiLangLG.generate('SomethingWentWrong', {
         message: `${ error }`
     }, context.activity.locale);
     console.error(langResponse);
@@ -72,6 +83,8 @@ const bot = new DialogBot(conversationState, userState, dialog);
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }.`);
     console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
@@ -79,9 +92,7 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 });
 
 // Listen for incoming requests.
-server.post('/api/messages', (req, res) => {
-    adapter.processActivity(req, res, async (context) => {
-        // Route the message to the bot's main handler.
-        await bot.run(context);
-    });
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => bot.run(context));
 });

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
@@ -27,7 +27,9 @@ const { UserProfileDialog } = require('./dialogs/userProfileDialog');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/package.json
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
-        "botbuilder-lg": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder-lg": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "path": "^0.12.7",
         "restify": "~8.5.1"

--- a/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/.env
+++ b/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
+++ b/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
@@ -12,18 +12,29 @@ const { Templates } = require('botbuilder-lg');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState } = require('botbuilder');
+const {
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    ConversationState,
+    createBotFrameworkAuthenticationFromConfiguration,
+    MemoryStorage,
+    UserState
+} = require('botbuilder');
 
 // Import our custom bot class that provides a turn handling function.
 const { DialogBot } = require('./bots/dialogBot');
 const { UserProfileDialog } = require('./dialogs/userProfileDialog');
 
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
 // Create the adapter. See https://aka.ms/about-bot-adapter to learn more about using information from
 // the .bot file when configuring your adapter.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
-});
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Create template engine for language generation.
 const lgTemplates = Templates.parseFile('./Resources/AdapterWithErrorHandler.lg');
@@ -32,7 +43,7 @@ const lgTemplates = Templates.parseFile('./Resources/AdapterWithErrorHandler.lg'
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       application insights. See https://aka.ms/bottelemetry for telemetry
     //       configuration instructions.
     console.error(lgTemplates.evaluate('SomethingWentWrong', {
         message: `${ error }`
@@ -68,6 +79,8 @@ const bot = new DialogBot(conversationState, userState, dialog);
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }.`);
     console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
@@ -75,9 +88,7 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 });
 
 // Listen for incoming requests.
-server.post('/api/messages', (req, res) => {
-    adapter.processActivity(req, res, async (context) => {
-        // Route the message to the bot's main handler.
-        await bot.run(context);
-    });
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => bot.run(context));
 });

--- a/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
+++ b/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
@@ -27,7 +27,9 @@ const { UserProfileDialog } = require('./dialogs/userProfileDialog');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/package.json
+++ b/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
-        "botbuilder-lg": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder-lg": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "path": "^0.12.7",
         "restify": "~8.5.1"

--- a/samples/javascript_nodejs/language-generation/06.using-cards/.env
+++ b/samples/javascript_nodejs/language-generation/06.using-cards/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/language-generation/06.using-cards/index.js
+++ b/samples/javascript_nodejs/language-generation/06.using-cards/index.js
@@ -28,7 +28,9 @@ const { MainDialog } = require('./dialogs/mainDialog');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/language-generation/06.using-cards/index.js
+++ b/samples/javascript_nodejs/language-generation/06.using-cards/index.js
@@ -13,17 +13,28 @@ const { Templates } = require('botbuilder-lg');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const { BotFrameworkAdapter, MemoryStorage, ConversationState, UserState } = require('botbuilder');
+const {
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    ConversationState,
+    createBotFrameworkAuthenticationFromConfiguration,
+    MemoryStorage,
+    UserState
+} = require('botbuilder');
 
 // This bot's main dialog.
 const { RichCardsBot } = require('./bots/richCardsBot');
 const { MainDialog } = require('./dialogs/mainDialog');
 
-// Create adapter. See https://aka.ms/about-bot-adapter to learn more about adapters.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword
 });
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
+// Create adapter. See https://aka.ms/about-bot-adapter to learn more about adapters.
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Create template engine for language generation.
 const lgTemplates = Templates.parseFile('./resources/AdapterWithErrorHandler.lg');
@@ -32,7 +43,7 @@ const lgTemplates = Templates.parseFile('./resources/AdapterWithErrorHandler.lg'
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       application insights. See https://aka.ms/bottelemetry for telemetry
     //       configuration instructions.
     console.error(lgTemplates.evaluate('SomethingWentWrong', {
         message: `${ error }`
@@ -69,6 +80,8 @@ const bot = new RichCardsBot(conversationState, userState, dialog);
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }.`);
     console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
@@ -76,10 +89,7 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 });
 
 // Listen for incoming activities and route them to your bot main dialog.
-server.post('/api/messages', (req, res) => {
+server.post('/api/messages', async (req, res) => {
     // Route received a request to adapter for processing
-    adapter.processActivity(req, res, async (turnContext) => {
-        // route to bot activity handler.
-        await bot.run(turnContext);
-    });
+    await adapter.process(req, res, (context) => bot.run(context));
 });

--- a/samples/javascript_nodejs/language-generation/06.using-cards/package.json
+++ b/samples/javascript_nodejs/language-generation/06.using-cards/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
-        "botbuilder-lg": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder-lg": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/language-generation/13.core-bot/.env
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/.env
@@ -1,0 +1,7 @@
+MicrosoftAppType=
+MicrosoftAppId=
+MicrosoftAppPassword=
+MicrosoftAppTenantId=
+LuisAppId=
+LuisAPIKey=
+LuisAPIHostName=

--- a/samples/javascript_nodejs/language-generation/13.core-bot/.gitignore
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 .nyc_output/
 .vscode/
-.env

--- a/samples/javascript_nodejs/language-generation/13.core-bot/index.js
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/index.js
@@ -15,7 +15,15 @@ const { Templates } = require('botbuilder-lg');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const { BotFrameworkAdapter, ConversationState, InputHints, MemoryStorage, UserState } = require('botbuilder');
+const {
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    ConversationState,
+    createBotFrameworkAuthenticationFromConfiguration,
+    InputHints,
+    MemoryStorage,
+    UserState
+} = require('botbuilder');
 
 const { FlightBookingRecognizer } = require('./dialogs/flightBookingRecognizer');
 
@@ -27,12 +35,16 @@ const { MainDialog } = require('./dialogs/mainDialog');
 const { BookingDialog } = require('./dialogs/bookingDialog');
 const BOOKING_DIALOG = 'bookingDialog';
 
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
-});
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Create template engine for language generation.
 console.log(path.join(__dirname, './resources/AdapterWithErrorHandler.lg'));
@@ -42,7 +54,7 @@ const lgTemplates = Templates.parseFile(path.join(__dirname, './resources/Adapte
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       application insights. See https://aka.ms/bottelemetry for telemetry
     //       configuration instructions.
     console.error(lgTemplates.evaluate('SomethingWentWrong', {
         message: `${ error }`
@@ -88,6 +100,8 @@ const bot = new DialogAndWelcomeBot(conversationState, userState, dialog);
 
 // Create HTTP server
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }`);
     console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
@@ -95,10 +109,7 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 });
 
 // Listen for incoming activities and route them to your bot main dialog.
-server.post('/api/messages', (req, res) => {
+server.post('/api/messages', async (req, res) => {
     // Route received a request to adapter for processing
-    adapter.processActivity(req, res, async (turnContext) => {
-        // route to bot activity handler.
-        await bot.run(turnContext);
-    });
+    await adapter.process(req, res, (context) => bot.run(context));
 });

--- a/samples/javascript_nodejs/language-generation/13.core-bot/index.js
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/index.js
@@ -37,7 +37,9 @@ const BOOKING_DIALOG = 'bookingDialog';
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/language-generation/13.core-bot/package.json
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/package.json
@@ -17,11 +17,11 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.14.0",
-        "botbuilder-ai": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
-        "botbuilder-testing": "~4.14.0",
-        "botbuilder-lg": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-ai": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder-testing": "~4.15.0-rc0",
+        "botbuilder-lg": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/language-generation/20.custom-functions/.env
+++ b/samples/javascript_nodejs/language-generation/20.custom-functions/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/language-generation/20.custom-functions/index.js
+++ b/samples/javascript_nodejs/language-generation/20.custom-functions/index.js
@@ -24,7 +24,9 @@ const { EchoBot } = require('./bot');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/language-generation/20.custom-functions/index.js
+++ b/samples/javascript_nodejs/language-generation/20.custom-functions/index.js
@@ -13,13 +13,26 @@ const { Templates } = require('botbuilder-lg');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const { BotFrameworkAdapter } = require('botbuilder');
+const {
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration,
+} = require('botbuilder');
 
 // This bot's main dialog.
 const { EchoBot } = require('./bot');
 
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
 // Create HTTP server
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, () => {
     console.log(`\n${ server.name } listening to ${ server.url }`);
     console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
@@ -28,10 +41,7 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about how bots work.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
-});
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 const lgTemplates = Templates.parseFile(path.join(__dirname, './resources/AdapterWithErrorHandler.lg'));
 
@@ -39,7 +49,7 @@ const lgTemplates = Templates.parseFile(path.join(__dirname, './resources/Adapte
 const onTurnErrorHandler = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       application insights. See https://aka.ms/bottelemetry for telemetry
     //       configuration instructions.
     console.error(lgTemplates.evaluate('SomethingWentWrong', {
         message: `${ error }`
@@ -58,33 +68,25 @@ const onTurnErrorHandler = async (context, error) => {
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 
-// Set the onTurnError for the singleton BotFrameworkAdapter.
+// Set the onTurnError for the singleton CloudAdapter.
 adapter.onTurnError = onTurnErrorHandler;
 
 // Create the main dialog.
 const myBot = new EchoBot();
 
 // Listen for incoming requests.
-server.post('/api/messages', (req, res) => {
-    adapter.processActivity(req, res, async (context) => {
-        // Route to main dialog.
-        await myBot.run(context);
-    });
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => myBot.run(context));
 });
 
 // Listen for Upgrade requests for Streaming.
-server.on('upgrade', (req, socket, head) => {
+server.on('upgrade', async (req, socket, head) => {
     // Create an adapter scoped to this WebSocket connection to allow storing session data.
-    const streamingAdapter = new BotFrameworkAdapter({
-        appId: process.env.MicrosoftAppId,
-        appPassword: process.env.MicrosoftAppPassword
-    });
-    // Set onTurnError for the BotFrameworkAdapter created for each connection.
+    const streamingAdapter = new CloudAdapter(botFrameworkAuthentication);
+
+    // Set onTurnError for the CloudAdapter created for each connection.
     streamingAdapter.onTurnError = onTurnErrorHandler;
 
-    streamingAdapter.useWebSocket(req, socket, head, async (context) => {
-        // After connecting via WebSocket, run this logic for every request sent over
-        // the WebSocket connection.
-        await myBot.run(context);
-    });
+    await streamingAdapter.process(req, socket, head, (context) => bot.run(context));
 });

--- a/samples/javascript_nodejs/language-generation/20.custom-functions/package.json
+++ b/samples/javascript_nodejs/language-generation/20.custom-functions/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
-        "botbuilder-lg": "~4.14.0",
-        "adaptive-expressions": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-lg": "~4.15.0-rc0",
+        "adaptive-expressions": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },


### PR DESCRIPTION
Addresses # 3526

## Description
This PR updates the **_language-generation_** samples, adding support for MSI and SingleTenant App types.

### Detailed Changes
- Updated the **_botbuilder_** dependency to the RC0 version.
- Updated **_index.js_** to pass the new parameters AppType and AppTenantId to the _ConfigurationServiceClientCredentialFactory_ instance.
- Added the new settings _MicrosoftAppType_ and _MicrosoftAppTenantId_ to the **_env_** file.
- Added missing .env file for sample _13.core-bot_.

This PR updates the following samples under the language-generation folder:
- 05.a.multi-turn-prompt-with-language-fallback
- 05.multi-turn-prompt
- 06.using-cards
- 13.core-bot
- 20.custom-functions

## Testing
The following images show one of the samples, the _20.custom-functions_, working with the three app types: MultiTenant, SingleTenant, and MSI.
![image](https://user-images.githubusercontent.com/44245136/138345528-38dc01fa-fe20-420e-91cf-7f3f4adad65e.png)
