### PR TITLE
[#3550] Port CloudAdapter & MSI to TypeScript samples (2/2)

### DIFF
--- a/samples/typescript_nodejs/16.proactive-messages/.env
+++ b/samples/typescript_nodejs/16.proactive-messages/.env
@@ -1,0 +1,4 @@
+MicrosoftAppType=
+MicrosoftAppId=
+MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/typescript_nodejs/16.proactive-messages/.gitignore
+++ b/samples/typescript_nodejs/16.proactive-messages/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 lib
-.env

--- a/samples/typescript_nodejs/16.proactive-messages/package.json
+++ b/samples/typescript_nodejs/16.proactive-messages/package.json
@@ -18,7 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"

--- a/samples/typescript_nodejs/50.teams-messaging-extensions-search/.env
+++ b/samples/typescript_nodejs/50.teams-messaging-extensions-search/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/typescript_nodejs/50.teams-messaging-extensions-search/package.json
+++ b/samples/typescript_nodejs/50.teams-messaging-extensions-search/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "axios": "^0.21.2",
-    "botbuilder": "~4.14.0",
+    "botbuilder": "~4.15.0-rc0",
     "dotenv": "^8.2.0",
     "replace": "~1.2.0",
     "restify": "~8.5.1"

--- a/samples/typescript_nodejs/50.teams-messaging-extensions-search/src/index.ts
+++ b/samples/typescript_nodejs/50.teams-messaging-extensions-search/src/index.ts
@@ -10,7 +10,11 @@ import { INodeSocket } from 'botframework-streaming';
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-import { BotFrameworkAdapter } from 'botbuilder';
+import {
+  CloudAdapter,
+  ConfigurationServiceClientCredentialFactory,
+  createBotFrameworkAuthenticationFromConfiguration
+} from 'botbuilder';
 
 // This bot's main dialog.
 import { TeamsMessagingExtensionsSearchBot } from './teamsMessagingExtensionsSearchBot';
@@ -19,12 +23,18 @@ import { TeamsMessagingExtensionsSearchBot } from './teamsMessagingExtensionsSea
 const ENV_FILE = path.join( __dirname, '..', '.env' );
 config( { path: ENV_FILE } );
 
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+  MicrosoftAppId: process.env.MicrosoftAppId,
+  MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+  MicrosoftAppType: process.env.MicrosoftAppType,
+  MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
 // Create adapter.
-// See https://aka.ms/about-bot-adapter to learn more about adapters.
-const adapter = new BotFrameworkAdapter( {
-  appId: process.env.MicrosoftAppId,
-  appPassword: process.env.MicrosoftAppPassword
-} );
+// See https://aka.ms/about-bot-adapter to learn more about how bots work.
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Catch-all for errors.
 const onTurnErrorHandler = async ( context, error ) => {
@@ -46,7 +56,7 @@ const onTurnErrorHandler = async ( context, error ) => {
   await context.sendActivity( 'To continue to run this bot, please fix the bot source code.' );
 };
 
-// Set the onTurnError for the singleton BotFrameworkAdapter.
+// Set the onTurnError for the singleton CloudAdapter.
 adapter.onTurnError = onTurnErrorHandler;
 
 // Create the bot that will handle incoming messages.
@@ -54,6 +64,8 @@ const bot = new TeamsMessagingExtensionsSearchBot();
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen( process.env.port || process.env.PORT || 3978, () => {
   console.log( `\n${ server.name } listening to ${ server.url }` );
   console.log( '\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator' );
@@ -61,25 +73,18 @@ server.listen( process.env.port || process.env.PORT || 3978, () => {
 } );
 
 // Listen for incoming requests.
-server.post( '/api/messages', ( req, res ) => {
-  adapter.processActivity( req, res, async ( context ) => {
-    await bot.run( context );
-  } );
-} );
+server.post('/api/messages', async (req, res) => {
+  // Route received a request to adapter for processing
+  await adapter.process(req, res, (context) => bot.run(context));
+});
 
 // Listen for Upgrade requests for Streaming.
-server.on( 'upgrade', ( req, socket, head ) => {
+server.on('upgrade', async (req, socket, head) => {
   // Create an adapter scoped to this WebSocket connection to allow storing session data.
-  const streamingAdapter = new BotFrameworkAdapter( {
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
-  } );
-  // Set onTurnError for the BotFrameworkAdapter created for each connection.
+  const streamingAdapter = new CloudAdapter(botFrameworkAuthentication);
+
+  // Set onTurnError for the CloudAdapter created for each connection.
   streamingAdapter.onTurnError = onTurnErrorHandler;
 
-  streamingAdapter.useWebSocket(req, socket as unknown as INodeSocket, head, async (context) => {
-    // After connecting via WebSocket, run this logic for every request sent over
-    // the WebSocket connection.
-    await bot.run( context );
-  } );
-} );
+  await streamingAdapter.process(req, socket as unknown as INodeSocket, head, (context) => bot.run(context));
+});

--- a/samples/typescript_nodejs/51.teams-messaging-extensions-action/.env
+++ b/samples/typescript_nodejs/51.teams-messaging-extensions-action/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/typescript_nodejs/51.teams-messaging-extensions-action/package.json
+++ b/samples/typescript_nodejs/51.teams-messaging-extensions-action/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "axios": "^0.21.2",
-    "botbuilder": "~4.14.0",
+    "botbuilder": "~4.15.0-rc0",
     "dotenv": "^8.2.0",
     "replace": "~1.2.0",
     "restify": "~8.5.1"

--- a/samples/typescript_nodejs/51.teams-messaging-extensions-action/src/index.ts
+++ b/samples/typescript_nodejs/51.teams-messaging-extensions-action/src/index.ts
@@ -11,7 +11,9 @@ import { INodeSocket } from 'botframework-streaming';
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
 import {
-  BotFrameworkAdapter,
+  CloudAdapter,
+  ConfigurationServiceClientCredentialFactory,
+  createBotFrameworkAuthenticationFromConfiguration,
   TurnContext,
   WebRequest,
   WebResponse
@@ -24,12 +26,18 @@ import { TeamsMessagingExtensionsActionBot } from './teamsMessagingExtensionsAct
 const ENV_FILE = path.join( __dirname, '..', '.env' );
 config( { path: ENV_FILE } );
 
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+  MicrosoftAppId: process.env.MicrosoftAppId,
+  MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+  MicrosoftAppType: process.env.MicrosoftAppType,
+  MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.
-const adapter = new BotFrameworkAdapter( {
-  appId: process.env.MicrosoftAppId,
-  appPassword: process.env.MicrosoftAppPassword
-} );
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Catch-all for errors.
 const onTurnErrorHandler = async ( context, error ) => {
@@ -51,7 +59,7 @@ const onTurnErrorHandler = async ( context, error ) => {
   await context.sendActivity( 'To continue to run this bot, please fix the bot source code.' );
 };
 
-// Set the onTurnError for the singleton BotFrameworkAdapter.
+// Set the onTurnError for the singleton CloudAdapter.
 adapter.onTurnError = onTurnErrorHandler;
 
 // Create the bot that will handle incoming messages.
@@ -59,6 +67,8 @@ const bot = new TeamsMessagingExtensionsActionBot();
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen( process.env.port || process.env.PORT || 3978, () => {
   console.log( `\n${ server.name } listening to ${ server.url }` );
   console.log( '\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator' );
@@ -66,25 +76,18 @@ server.listen( process.env.port || process.env.PORT || 3978, () => {
 } );
 
 // Listen for incoming requests.
-server.post( '/api/messages', ( req, res ) => {
-  adapter.processActivity( req, res, async ( context ) => {
-    await bot.run( context );
-  } );
-} );
+server.post('/api/messages', async (req, res) => {
+  // Route received a request to adapter for processing
+  await adapter.process(req, res, (context) => bot.run(context));
+});
 
 // Listen for Upgrade requests for Streaming.
-server.on( 'upgrade', ( req , socket, head ) => {
+server.on('upgrade', async (req, socket, head) => {
   // Create an adapter scoped to this WebSocket connection to allow storing session data.
-  const streamingAdapter = new BotFrameworkAdapter( {
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
-  } );
-  // Set onTurnError for the BotFrameworkAdapter created for each connection.
+  const streamingAdapter = new CloudAdapter(botFrameworkAuthentication);
+
+  // Set onTurnError for the CloudAdapter created for each connection.
   streamingAdapter.onTurnError = onTurnErrorHandler;
 
-  streamingAdapter.useWebSocket(req, socket as unknown as INodeSocket, head, async (context) => {
-    // After connecting via WebSocket, run this logic for every request sent over
-    // the WebSocket connection.
-    await bot.run( context );
-  } );
-} );
+  await streamingAdapter.process(req, socket as unknown as INodeSocket, head, (context) => bot.run(context));
+});

--- a/samples/typescript_nodejs/57.teams-conversation-bot/.env
+++ b/samples/typescript_nodejs/57.teams-conversation-bot/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/typescript_nodejs/57.teams-conversation-bot/package.json
+++ b/samples/typescript_nodejs/57.teams-conversation-bot/package.json
@@ -18,7 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"

--- a/samples/typescript_nodejs/57.teams-conversation-bot/src/index.ts
+++ b/samples/typescript_nodejs/57.teams-conversation-bot/src/index.ts
@@ -10,7 +10,11 @@ import { INodeSocket } from 'botframework-streaming';
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-import { BotFrameworkAdapter } from 'botbuilder';
+import {
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration
+} from 'botbuilder';
 
 // This bot's main dialog.
 import { TeamsConversationBot } from './teamsConversationBot';
@@ -19,12 +23,18 @@ import { TeamsConversationBot } from './teamsConversationBot';
 const ENV_FILE = path.join(__dirname, '..', '.env');
 config({ path: ENV_FILE });
 
-// Create adapter.
-// See https://aka.ms/about-bot-adapter to learn more about adapters.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
+ 
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
+// Create adapter.
+// See https://aka.ms/about-bot-adapter to learn more about how bots work.
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Catch-all for errors.
 const onTurnErrorHandler = async ( context, error ) => {
@@ -46,7 +56,7 @@ const onTurnErrorHandler = async ( context, error ) => {
     await context.sendActivity( 'To continue to run this bot, please fix the bot source code.' );
 };
 
-// Set the onTurnError for the singleton BotFrameworkAdapter.
+// Set the onTurnError for the singleton CloudAdapter.
 adapter.onTurnError = onTurnErrorHandler;
 
 // Create the bot that will handle incoming messages.
@@ -54,6 +64,8 @@ const bot = new TeamsConversationBot();
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, () => {
     console.log( `\n${ server.name } listening to ${ server.url }` );
     console.log( '\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator' );
@@ -61,25 +73,18 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 });
 
 // Listen for incoming requests.
-server.post('/api/messages', (req, res) => {
-    adapter.processActivity( req, res, async ( context ) => {
-        await bot.run(context);
-    });
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => bot.run(context));
 });
 
 // Listen for Upgrade requests for Streaming.
-server.on( 'upgrade', ( req, socket, head ) => {
+server.on('upgrade', async (req, socket, head) => {
     // Create an adapter scoped to this WebSocket connection to allow storing session data.
-    const streamingAdapter = new BotFrameworkAdapter( {
-        appId: process.env.MicrosoftAppId,
-        appPassword: process.env.MicrosoftAppPassword
-    } );
-    // Set onTurnError for the BotFrameworkAdapter created for each connection.
+    const streamingAdapter = new CloudAdapter(botFrameworkAuthentication);
+
+    // Set onTurnError for the CloudAdapter created for each connection.
     streamingAdapter.onTurnError = onTurnErrorHandler;
 
-    streamingAdapter.useWebSocket(req, socket as unknown as INodeSocket, head, async (context) => {
-        // After connecting via WebSocket, run this logic for every request sent over
-        // the WebSocket connection.
-        await bot.run( context );
-    } );
-} );
+    await streamingAdapter.process(req, socket as unknown as INodeSocket, head, (context) => bot.run(context));
+});

--- a/samples/typescript_nodejs/57.teams-conversation-bot/src/teamsConversationBot.ts
+++ b/samples/typescript_nodejs/57.teams-conversation-bot/src/teamsConversationBot.ts
@@ -5,7 +5,6 @@ import {
     ActionTypes,
     CardFactory,
     ChannelAccount,
-    CloudAdapter,
     ConversationParameters,
     MessageFactory,
     TeamInfo,
@@ -159,16 +158,13 @@ export class TeamsConversationBot extends TeamsActivityHandler {
             console.log( 'a ', teamMember );
             const message = MessageFactory.text( `Hello ${ teamMember.givenName } ${ teamMember.surname }. I'm a Teams conversation bot.` );
 
-            let botAdapter: CloudAdapter;
-            botAdapter = context.adapter as CloudAdapter;
-
             const convoParams = {
                 members: [teamMember],
                 tenantId: context.activity.channelData.tenant.id,
                 activity: context.activity
             } as ConversationParameters;
             
-            await botAdapter.createConversationAsync (
+            await context.adapter.createConversationAsync (
                 process.env.MicrosoftAppId,
                 context.activity.channelId,
                 context.activity.serviceUrl,

--- a/samples/typescript_nodejs/57.teams-conversation-bot/src/teamsConversationBot.ts
+++ b/samples/typescript_nodejs/57.teams-conversation-bot/src/teamsConversationBot.ts
@@ -3,7 +3,6 @@
 
 import {
     ActionTypes,
-    BotFrameworkAdapter,
     CardFactory,
     ChannelAccount,
     CloudAdapter,
@@ -160,8 +159,6 @@ export class TeamsConversationBot extends TeamsActivityHandler {
             console.log( 'a ', teamMember );
             const message = MessageFactory.text( `Hello ${ teamMember.givenName } ${ teamMember.surname }. I'm a Teams conversation bot.` );
 
-            // const ref = TurnContext.getConversationReference( context.activity );
-            // ref.user = teamMember;
             let botAdapter: CloudAdapter;
             botAdapter = context.adapter as CloudAdapter;
 

--- a/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/.env
+++ b/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/package.json
+++ b/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/package.json
@@ -18,7 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"

--- a/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/src/index.ts
+++ b/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/src/index.ts
@@ -10,7 +10,11 @@ import { INodeSocket } from 'botframework-streaming';
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-import { BotFrameworkAdapter } from 'botbuilder';
+import {
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration
+} from 'botbuilder';
 
 // This bot's main dialog.
 import { TeamsStartNewThreadInChannel } from './teamsStartNewThreadInChannel';
@@ -19,12 +23,18 @@ import { TeamsStartNewThreadInChannel } from './teamsStartNewThreadInChannel';
 const ENV_FILE = path.join( __dirname, '..', '.env' );
 config( { path: ENV_FILE } );
 
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
+});
+ 
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.
-const adapter = new BotFrameworkAdapter( {
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
-} );
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Catch-all for errors.
 const onTurnErrorHandler = async ( context, error ) => {
@@ -46,7 +56,7 @@ const onTurnErrorHandler = async ( context, error ) => {
     await context.sendActivity( 'To continue to run this bot, please fix the bot source code.' );
 };
 
-// Set the onTurnError for the singleton BotFrameworkAdapter.
+// Set the onTurnError for the singleton CloudAdapter.
 adapter.onTurnError = onTurnErrorHandler;
 
 // Create the bot that will handle incoming messages.
@@ -54,6 +64,8 @@ const bot = new TeamsStartNewThreadInChannel();
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen( process.env.port || process.env.PORT || 3978, () => {
     console.log( `\n${ server.name } listening to ${ server.url }` );
     console.log( '\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator' );
@@ -61,25 +73,18 @@ server.listen( process.env.port || process.env.PORT || 3978, () => {
 } );
 
 // Listen for incoming requests.
-server.post( '/api/messages', ( req, res ) => {
-    adapter.processActivity( req, res, async ( context ) => {
-        await bot.run( context );
-    } );
-} );
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => bot.run(context));
+});
 
 // Listen for Upgrade requests for Streaming.
-server.on( 'upgrade', ( req, socket, head ) => {
+server.on('upgrade', async (req, socket, head) => {
     // Create an adapter scoped to this WebSocket connection to allow storing session data.
-    const streamingAdapter = new BotFrameworkAdapter( {
-        appId: process.env.MicrosoftAppId,
-        appPassword: process.env.MicrosoftAppPassword
-    } );
-    // Set onTurnError for the BotFrameworkAdapter created for each connection.
+    const streamingAdapter = new CloudAdapter(botFrameworkAuthentication);
+
+    // Set onTurnError for the CloudAdapter created for each connection.
     streamingAdapter.onTurnError = onTurnErrorHandler;
 
-    streamingAdapter.useWebSocket(req, socket as unknown as INodeSocket, head, async (context) => {
-        // After connecting via WebSocket, run this logic for every request sent over
-        // the WebSocket connection.
-        await bot.run( context );
-    } );
-} );
+    await streamingAdapter.process(req, socket as unknown as INodeSocket, head, (context) => bot.run(context));
+});

--- a/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/src/teamsStartNewThreadInChannel.ts
+++ b/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/src/teamsStartNewThreadInChannel.ts
@@ -3,8 +3,8 @@
 
 import {
     Activity,
-    BotFrameworkAdapter,
     ChannelAccount,
+    CloudAdapter,
     ConversationReference,
     ConversationParameters,
     MessageFactory,
@@ -22,13 +22,15 @@ export class TeamsStartNewThreadInChannel extends TeamsActivityHandler {
             const message = MessageFactory.text( 'This will be the first message in a new thread' );
             const newConversation = await this.teamsCreateConversation( context, channelAccount, teamsChannelId, message );
 
-            await context.adapter.continueConversation( newConversation[ 0 ],
+            await context.adapter.continueConversationAsync(
+                process.env.MicrosoftAppId,
+                newConversation[ 0 ],
                 async ( t ) => {
                     await t.sendActivity( MessageFactory.text( 'This will be the first response to the new thread' ) );
-                } );
+                });
 
             await next();
-        } );
+        });
     }
 
     public async teamsCreateConversation( context: TurnContext, channelAccount: ChannelAccount, teamsChannelId: string, message: Partial<Activity> ): Promise<any> {
@@ -44,8 +46,10 @@ export class TeamsStartNewThreadInChannel extends TeamsActivityHandler {
             activity: message
         } as ConversationParameters;
 
-        const botAdapter = context.adapter as BotFrameworkAdapter;
-        const connectorClient = botAdapter.createConnectorClient( context.activity.serviceUrl );
+        const botAdapter = context.adapter as CloudAdapter;
+        const connectorFactory = context.turnState.get(botAdapter.ConnectorFactoryKey);
+        const connectorClient = await connectorFactory.create(context.activity.serviceUrl);
+
         const conversationResourceResponse = await connectorClient.conversations.createConversation( conversationParameters );
         const conversationReference = TurnContext.getConversationReference( context.activity ) as ConversationReference;
         conversationReference.conversation.id = conversationResourceResponse.id;


### PR DESCRIPTION
Addresses # 3550

## Description
This PR updates the TypeScript samples, adding support for CloudAdapter and MSI.

### Detailed Changes
- Updated the **_botbuilder_** dependency to the RC0 version.
- Updated **_index.js_** to:
   - Replace BotFrameworkAdapter with CloudAdapter.
   - Added an instance of ConfigurationServiceClientCredentialFactory to manage credentials.
   - Pass the new parameters AppType and AppTenantId to the _ConfigurationServiceClientCredentialFactory_ instance.
- Added the new settings _MicrosoftAppType_ and _MicrosoftAppTenantId_ to the **_env_** file.
- Added missing **env** files.
- Updated **TeamsConversationBot** and **TeamsStartNewThreadInChannel** classes to adapt the code to the new adapter's methods.

This PR updates the following samples:
- 16.proactive-messages
- 50.teams-messaging-extensions-search
- 51.teams-messaging-extensions-action
- 57.teams-conversation-bot
- 58.teams-start-new-thread-in-channel

## Testing
The following images show the teams-messaging-extensions-action sample properly configured and working with SingleTenant.
![image](https://user-images.githubusercontent.com/44245136/139736656-565ced9a-9293-4de0-9603-304d214d77ab.png)

