### PR TITLE
[#3441] Fix JS 51.teams-messaging-extensions-action sample when the bot is not part of the conversation roster

### DIFF
--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/.env
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/.env
@@ -2,3 +2,4 @@ MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
 MicrosoftAppTenantId=
+BaseUrl=

--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/bots/teamsMessagingExtensionsActionBot.js
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/bots/teamsMessagingExtensionsActionBot.js
@@ -15,8 +15,6 @@ class TeamsMessagingExtensionsActionBot extends TeamsActivityHandler {
             return shareMessageCommand(context, action);
         case 'webView':
             return await webViewResponse(action);
-        default:
-            throw new Error('NotImplemented');
         }
     }
 
@@ -89,7 +87,7 @@ function GetJustInTimeCardAttachment() {
             {
                 text: 'Looks like you have not used Action Messaging Extension app in this team/chat. Please click **Continue** to add this app.',
                 type: 'TextBlock',
-                wrap: 'bolder'
+                wrap: true
             }
         ],
         type: 'AdaptiveCard',
@@ -105,7 +103,7 @@ function GetAdaptiveCardAttachment() {
                 text: 'This app is installed in this conversation. You can now use it to do some great stuff!!!',
                 type: 'TextBlock',
                 isSubtle: false,
-                warp: true
+                wrap: true
             }
         ],
         type: 'AdaptiveCard',
@@ -113,7 +111,7 @@ function GetAdaptiveCardAttachment() {
     });
 }
 
-function createCardCommand(action) {
+function createCardCommand(context, action) {
     // The user has chosen to create a card by choosing the 'Create Card' context menu command.
     const data = action.data;
     const heroCard = CardFactory.heroCard(data.title, data.text);
@@ -131,7 +129,7 @@ function createCardCommand(action) {
     };
 }
 
-function shareMessageCommand(action) {
+function shareMessageCommand(context, action) {
     // The user has chosen to share a message by choosing the 'Share Message' context menu command.
     let userName = 'unknown';
     if (action.messagePayload.from &&


### PR DESCRIPTION
Fixes # 3441

## Description
This PR fixes an issue when fetching for conversation roster information, the bot fails with the message `The bot is not part of the conversation roster.` instead of suggesting to add the app.

> **Note:** The warning error from the Azure Bot Channels section will still appear (in DotNet, it also does), but now the functionality will work as expected.

### Detailed Changes
- Added missing `BaseUrl` into the `.env` file.
- Added missing `context` parameter to the `createCardCommand` and `shareMessageCommand` methods.
- Fix the `wrap` property, partially causing this issue for `GetJustInTimeCardAttachment` and `GetAdaptiveCardAttachment`.
- Removed the `default` option that throws `NotImplemented` from the `switch` just like in DotNet, because when the bot is in the roster, and the user clicks in `Close` the app will throw this error, whereas in DotNet this doesn't happen.

## Testing
The following images show the bot failing before the change and how it will work after it.
![image](https://user-images.githubusercontent.com/62260472/139941364-b4082d39-38bc-4769-9d0f-8c7ed641f934.png)
![image](https://user-images.githubusercontent.com/62260472/139941368-7809de52-828a-4d28-896b-2df6cff1d5e3.png)