### PR TITLE
[#3459] Composer-Samples (csharp_dotnetcore) Fails to compile the bot, 'Runtime' does not exist in the namespace 'Microsoft.Bot.Builder.Integration'

### DIFF
--- a/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/.gitignore
+++ b/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/.gitignore
@@ -1,0 +1,2 @@
+# files generated during the lubuild process
+generated/

--- a/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Controllers/BotController.cs
+++ b/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Controllers/BotController.cs
@@ -1,11 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Builder.Integration.Runtime.Settings;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace SchoolNavigator.Controllers
 {
@@ -17,17 +19,23 @@ namespace SchoolNavigator.Controllers
     {
         private readonly Dictionary<string, IBotFrameworkHttpAdapter> _adapters = new Dictionary<string, IBotFrameworkHttpAdapter>();
         private readonly IBot _bot;
+        private readonly ILogger<BotController> _logger;
 
         public BotController(
-            IEnumerable<IBotFrameworkHttpAdapter> adapters, 
-            IEnumerable<AdapterSettings> adapterSettings, 
-            IBot bot)
+            IConfiguration configuration,
+            IEnumerable<IBotFrameworkHttpAdapter> adapters,
+            IBot bot,
+            ILogger<BotController> logger)
         {
             _bot = bot ?? throw new ArgumentNullException(nameof(bot));
+            _logger = logger;
+
+            var adapterSettings = configuration.GetSection(AdapterSettings.AdapterSettingsKey).Get<List<AdapterSettings>>() ?? new List<AdapterSettings>();
+            adapterSettings.Add(AdapterSettings.CoreBotAdapterSettings);
 
             foreach (var adapter in adapters ?? throw new ArgumentNullException(nameof(adapters)))
             {
-                var settings = adapterSettings.FirstOrDefault(s => s.Enabled && s.Name == adapter.GetType().FullName);
+                var settings = adapterSettings.FirstOrDefault(s => s.Enabled && s.Type == adapter.GetType().FullName);
 
                 if (settings != null)
                 {
@@ -43,17 +51,24 @@ namespace SchoolNavigator.Controllers
         {
             if (string.IsNullOrEmpty(route))
             {
+                _logger.LogError($"PostAsync: No route provided.");
                 throw new ArgumentNullException(nameof(route));
             }
-            
+
             if (_adapters.TryGetValue(route, out IBotFrameworkHttpAdapter adapter))
             {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogInformation($"PostAsync: routed '{route}' to {adapter.GetType().Name}");
+                }
+
                 // Delegate the processing of the HTTP POST to the appropriate adapter.
                 // The adapter will invoke the bot.
                 await adapter.ProcessAsync(Request, Response, _bot).ConfigureAwait(false);
             }
             else
             {
+                _logger.LogError($"PostAsync: No adapter registered and enabled for route {route}.");
                 throw new KeyNotFoundException($"No adapter registered and enabled for route {route}.");
             }
         }

--- a/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Controllers/SkillController.cs
+++ b/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Controllers/SkillController.cs
@@ -1,35 +1,42 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
 
 namespace SchoolNavigator.Controllers
 {
     /// <summary>
     /// A controller that handles skill replies to the bot.
-    /// This example uses the <see cref="SkillHandler"/> that is registered as a <see cref="ChannelServiceHandler"/> in startup.cs.
     /// </summary>
     [ApiController]
     [Route("api/skills")]
     public class SkillController : ChannelServiceController
     {
-        public SkillController(ChannelServiceHandler handler)
+        private readonly ILogger<SkillController> _logger;
+
+        public SkillController(ChannelServiceHandlerBase handler, ILogger<SkillController> logger)
             : base(handler)
         {
+            _logger = logger;
         }
 
         public override Task<IActionResult> ReplyToActivityAsync(string conversationId, string activityId, Activity activity)
         {
             try
             {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug($"ReplyToActivityAsync: conversationId={conversationId}, activityId={activityId}");
+                }
+
                 return base.ReplyToActivityAsync(conversationId, activityId, activity);
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                _logger.LogError(ex, $"ReplyToActivityAsync: {ex}");
                 throw;
             }
         }
@@ -38,11 +45,16 @@ namespace SchoolNavigator.Controllers
         {
             try
             {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug($"SendToConversationAsync: conversationId={conversationId}");
+                }
+
                 return base.SendToConversationAsync(conversationId, activity);
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                _logger.LogError(ex, $"SendToConversationAsync: {ex}");
                 throw;
             }
         }

--- a/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Program.cs
+++ b/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Program.cs
@@ -1,6 +1,6 @@
-﻿using System;
+using System;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Bot.Builder.Integration.Runtime.Extensions;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
@@ -17,10 +17,11 @@ namespace SchoolNavigator
             Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((hostingContext, builder) =>
                 {
-                    string applicationRoot = AppDomain.CurrentDomain.BaseDirectory;
-                    string settingsDirectory = "settings";
+                    var applicationRoot = AppDomain.CurrentDomain.BaseDirectory;
+                    var environmentName = hostingContext.HostingEnvironment.EnvironmentName;
+                    var settingsDirectory = "settings";
 
-                    builder.AddBotRuntimeConfiguration(applicationRoot, settingsDirectory);
+                    builder.AddBotRuntimeConfiguration(applicationRoot, settingsDirectory, environmentName);
 
                     builder.AddCommandLine(args);
                 })

--- a/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/SchoolNavigator.csproj
+++ b/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/SchoolNavigator.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Orchestrator" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Orchestrator" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.14.1" />
   </ItemGroup>
 </Project>

--- a/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Startup.cs
+++ b/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Startup.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Bot.Builder.Integration.Runtime.Extensions;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace SchoolNavigator
 {
@@ -10,7 +12,7 @@ namespace SchoolNavigator
     {
         public Startup(IConfiguration configuration)
         {
-            this.Configuration = configuration;
+            Configuration = configuration;
         }
 
         public IConfiguration Configuration { get; }
@@ -19,22 +21,36 @@ namespace SchoolNavigator
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers().AddNewtonsoftJson();
-            services.AddBotRuntime(this.Configuration);
+            services.AddBotRuntime(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#pragma warning disable CA1801 // Review unused parameters
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-#pragma warning restore CA1801 // Review unused parameters
         {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
             app.UseDefaultFiles();
-            app.UseStaticFiles();
+
+            // Set up custom content types - associating file extension to MIME type.
+            var provider = new FileExtensionContentTypeProvider();
+            provider.Mappings[".lu"] = "application/vnd.microsoft.lu";
+            provider.Mappings[".qna"] = "application/vnd.microsoft.qna";
+
+            // Expose static files in manifests folder for skill scenarios.
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                ContentTypeProvider = provider
+            });
             app.UseWebSockets();
-            app.UseRouting()
-               .UseEndpoints(endpoints =>
-               {
-                   endpoints.MapControllers();
-               });
+            app.UseRouting();
+            app.UseAuthorization();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
         }
     }
 }


### PR DESCRIPTION
Fixes # 3459

## Description
This PR fixes an issue when compiling the project, either using BotFramework-Composer or Visual Studio. The cause was that the   bot's codebase was outdated compared to the other composer samples. Updating it to the latest codebase structure, solved the issue.

### Detailed Changes
- Updated SchoolNavigator codebase from the latest generated samples from Composer.
- Updated the `.csproj` BotBuilder packages from `4.13.1` to `4.14.1` version.
- Added the `generated` folder to the `.gitignore`.

This PR updates the following sample
- composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator

## Testing
The following images show the bot failing to compile in Visual Studio and the bot working after the codebase update.
![image](https://user-images.githubusercontent.com/62260472/141134036-1967f846-d569-4f33-ad48-d4ce4efb34a6.png)
