### PR TITLE
[#3526] Update JS samples to 4.15.0 (part 1/2)

### DIFF
--- a/samples/javascript_nodejs/02.echo-bot/package.json
+++ b/samples/javascript_nodejs/02.echo-bot/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/03.welcome-users/package.json
+++ b/samples/javascript_nodejs/03.welcome-users/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/05.multi-turn-prompt/package.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "^8.2.0",
         "path": "^0.12.7",
         "restify": "~8.5.1"

--- a/samples/javascript_nodejs/06.using-cards/package.json
+++ b/samples/javascript_nodejs/06.using-cards/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/07.using-adaptive-cards/package.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/08.suggested-actions/package.json
+++ b/samples/javascript_nodejs/08.suggested-actions/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/11.qnamaker/package.json
+++ b/samples/javascript_nodejs/11.qnamaker/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-ai": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-ai": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/13.core-bot/package.json
+++ b/samples/javascript_nodejs/13.core-bot/package.json
@@ -17,10 +17,10 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-ai": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
-        "botbuilder-testing": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-ai": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
+        "botbuilder-testing": "~4.15.0",
         "dotenv": "^8.2.0",
         "moment-timezone": "~0.5.33",
         "restify": "~8.5.1"

--- a/samples/javascript_nodejs/14.nlp-with-orchestrator/package.json
+++ b/samples/javascript_nodejs/14.nlp-with-orchestrator/package.json
@@ -16,11 +16,11 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-ai": "~4.15.0-rc0",
-        "botbuilder-ai-orchestrator": "~4.15.0-rc0",
-        "botbuilder-azure": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-ai": "~4.15.0",
+        "botbuilder-ai-orchestrator": "~4.15.0",
+        "botbuilder-azure": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/15.handling-attachments/package.json
+++ b/samples/javascript_nodejs/15.handling-attachments/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "axios": "^0.21.2",
-    "botbuilder": "~4.15.0-rc0",
+    "botbuilder": "~4.15.0",
     "dotenv": "^8.2.0",
     "restify": "~8.5.1"
   },

--- a/samples/javascript_nodejs/16.proactive-messages/package.json
+++ b/samples/javascript_nodejs/16.proactive-messages/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "^8.2.0",
         "fetch-ponyfill": "^7.0.0",
         "moment": "^2.29.1",

--- a/samples/javascript_nodejs/17.multilingual-bot/package.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "node-fetch": "^2.6.0",
         "restify": "~8.5.1"

--- a/samples/javascript_nodejs/18.bot-authentication/package.json
+++ b/samples/javascript_nodejs/18.bot-authentication/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/19.custom-dialogs/package.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/21.corebot-app-insights/package.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/package.json
@@ -17,10 +17,10 @@
   "license": "MIT",
   "dependencies": {
     "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-    "botbuilder": "~4.15.0-rc0",
-    "botbuilder-ai": "~4.15.0-rc0",
-    "botbuilder-applicationinsights": "~4.15.0-rc0",
-    "botbuilder-dialogs": "~4.15.0-rc0",
+    "botbuilder": "~4.15.0",
+    "botbuilder-ai": "~4.15.0",
+    "botbuilder-applicationinsights": "~4.15.0",
+    "botbuilder-dialogs": "~4.15.0",
     "dotenv": "^8.2.0",
     "path": "^0.12.7",
     "restify": "~8.5.1"

--- a/samples/javascript_nodejs/23.facebook-events/package.json
+++ b/samples/javascript_nodejs/23.facebook-events/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/package.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/package.json
@@ -17,8 +17,8 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "~2.0.0",
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/25.message-reaction/package.json
+++ b/samples/javascript_nodejs/25.message-reaction/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/43.complex-dialog/package.json
+++ b/samples/javascript_nodejs/43.complex-dialog/package.json
@@ -12,8 +12,8 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/44.prompt-for-user-input/package.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-suite": "1.1.4",
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/45.state-management/package.json
+++ b/samples/javascript_nodejs/45.state-management/package.json
@@ -12,7 +12,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/46.teams-auth/package.json
+++ b/samples/javascript_nodejs/46.teams-auth/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/47.inspection/package.json
+++ b/samples/javascript_nodejs/47.inspection/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/49.qnamaker-all-features/package.json
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-ai": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-ai": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/50.teams-messaging-extensions-search/package.json
+++ b/samples/javascript_nodejs/50.teams-messaging-extensions-search/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "axios": "^0.21.2",
-    "botbuilder": "~4.15.0-rc0",
+    "botbuilder": "~4.15.0",
     "dotenv": "^8.2.0",
     "restify": "~8.5.1"
   },


### PR DESCRIPTION
Addresses # 3526

## Description
This PR updated the JS samples to the 4.15.0 version of the botbuilder packages.

### Detailed Changes
This PR includes the following samples:
- 02.echo-bot
- 03.welcome-user
- 05.multi-turn-prompt
- 06.using-cards
- 07.using-adaptive-cards
- 08.suggested-actions
- 11.qnamaker
- 13.core-bot
- 14.nlp-with-orchestrator
- 15.handling-attachments
- 16.Proactive messages
- 17.Multilingual bot
- 18.bot-authentication
- 19.Custom dialogs
- 21.Application Insights
- 23.Facebook events
- 24.bot-authentication-msgraph
- 25.message-reaction
- 43.complex-dialog
- 44.Basic custom prompts
- 45.state-management
- 46.teams-auth
- 47.Inspection middleware
- 49.qnamaker-all-features.
- 50.teams-messaging-extensions-search

## Testing
The following images show some of the bots working as expected
![image](https://user-images.githubusercontent.com/44245136/142058977-5e8884d8-dc89-4906-b3e1-4d23326c346d.png)

