### PR TITLE
[#3431] Remove dotnet core 2.1 templates from vsix - Update templates

### DIFF
--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.template.config/template.json
@@ -48,14 +48,6 @@
           {
             "choice": "netcoreapp3.1",
             "description": "Target netcoreapp3.1"
-          },
-            {
-            "choice": "netcoreapp2.2",
-            "description": "Target netcoreapp2.2"
-          },
-          {
-            "choice": "netcoreapp2.1",
-            "description": "Target netcoreapp2.1"
           }
         ],
         "replaces": "__NETCOREAPP_VERSION__",
@@ -68,25 +60,6 @@
         "description": "If specified, will also create a test project for your bot.",
         "isRequired": false
       },
-      "AspCoreAssemblyVersion": {
-        "type":"generated",
-        "generator": "switch",
-        "dataType": "string",
-        "replaces": "__MICROSOFT_ASPNETCORE_VERSION__",
-        "parameters": {
-          "evaluator": "C++",
-          "cases": [
-            {
-              "condition": "(Framework==\"netcoreapp2.2\")",
-              "value": "'Microsoft.AspNetCore' Version='2.2.0'"
-            },
-            {
-              "condition": "(Framework==\"netcoreapp2.1\")",
-              "value": "'Microsoft.AspNetCore' Version='2.1.6'"
-            }
-          ]
-        }
-      },
       "ReadmeNetCorePrereqVersion": {
         "type":"generated",
         "generator": "switch",
@@ -98,14 +71,6 @@
             {
               "condition": "(Framework==\"netcoreapp3.1\")",
               "value": "3.1"
-            },
-            {
-              "condition": "(Framework==\"netcoreapp2.2\")",
-              "value": "2.2"
-            },
-            {
-              "condition": "(Framework==\"netcoreapp2.1\")",
-              "value": "2.1"
             }
           ]
         }

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.template.config/template.json
@@ -47,37 +47,10 @@
         {
           "choice": "netcoreapp3.1",
           "description": "Target netcoreapp3.1"
-        },
-        {
-          "choice": "netcoreapp2.2",
-          "description": "Target netcoreapp2.2"
-        },
-        {
-          "choice": "netcoreapp2.1",
-          "description": "Target netcoreapp2.1"
         }
       ],
       "replaces": "__NETCOREAPP_VERSION__",
       "defaultValue": "netcoreapp3.1"
-    },
-    "AspCoreAssemblyVersion": {
-      "type":"generated",
-      "generator": "switch",
-      "dataType": "string",
-      "replaces": "__MICROSOFT_ASPNETCORE_VERSION__",
-      "parameters": {
-        "evaluator": "C++",
-        "cases": [
-          {
-            "condition": "(Framework==\"netcoreapp2.2\")",
-            "value": "'Microsoft.AspNetCore' Version='2.2.0'"
-          },
-          {
-            "condition": "(Framework==\"netcoreapp2.1\")",
-            "value": "'Microsoft.AspNetCore' Version='2.1.6'"
-          }
-        ]
-      }
     },
     "ReadmeNetCorePrereqVersion": {
       "type":"generated",
@@ -90,14 +63,6 @@
           {
             "condition": "(Framework==\"netcoreapp3.1\")",
             "value": "3.1"
-          },
-          {
-            "condition": "(Framework==\"netcoreapp2.2\")",
-            "value": "2.2"
-          },
-          {
-            "condition": "(Framework==\"netcoreapp2.1\")",
-            "value": "2.1"
           }
         ]
       }

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/.template.config/template.json
@@ -47,37 +47,10 @@
         {
           "choice": "netcoreapp3.1",
           "description": "Target netcoreapp3.1"
-        },
-        {
-          "choice": "netcoreapp2.2",
-          "description": "Target netcoreapp2.2"
-        },
-        {
-          "choice": "netcoreapp2.1",
-          "description": "Target netcoreapp2.1"
         }
       ],
       "replaces": "__NETCOREAPP_VERSION__",
       "defaultValue": "netcoreapp3.1"
-    },
-    "AspCoreAssemblyVersion": {
-      "type":"generated",
-      "generator": "switch",
-      "dataType": "string",
-      "replaces": "__MICROSOFT_ASPNETCORE_VERSION__",
-      "parameters": {
-        "evaluator": "C++",
-        "cases": [
-          {
-            "condition": "(Framework==\"netcoreapp2.2\")",
-            "value": "'Microsoft.AspNetCore' Version='2.2.0'"
-          },
-          {
-            "condition": "(Framework==\"netcoreapp2.1\")",
-            "value": "'Microsoft.AspNetCore' Version='2.1.6'"
-          }
-        ]
-      }
     },
     "ReadmeNetCorePrereqVersion": {
       "type":"generated",
@@ -90,14 +63,6 @@
           {
             "condition": "(Framework==\"netcoreapp3.1\")",
             "value": "3.1"
-          },
-          {
-            "condition": "(Framework==\"netcoreapp2.2\")",
-            "value": "2.2"
-          },
-          {
-            "condition": "(Framework==\"netcoreapp2.1\")",
-            "value": "2.1"
           }
         ]
       }

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/BotBuilderTemplatesVSIX.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/BotBuilderTemplatesVSIX.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.props')" />
+  <Import Project="packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -126,7 +126,7 @@
   <PropertyGroup>
     <PreBuildEvent>powershell New-Item -ItemType Directory -Force -Path '$(ProjectDir)ProjectTemplates'
 powershell Compress-Archive -Path '$(SolutionDir)UncompressedProjectTemplates\*' -DestinationPath $(ProjectDir)ProjectTemplates\Bot` Framework.zip -Force
-</PreBuildEvent>
+    </PreBuildEvent>
   </PropertyGroup>
   <Import Project="packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -135,11 +135,11 @@ powershell Compress-Archive -Path '$(SolutionDir)UncompressedProjectTemplates\*'
     </PropertyGroup>
     <Error Condition="!Exists('packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
     <Error Condition="!Exists('packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.props'))" />
-    <Error Condition="!Exists('packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.targets'))" />
   </Target>
   <Import Project="packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets" Condition="Exists('packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" />
-  <Import Project="packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.targets')" />
+  <Import Project="packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/packages.config
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.VisualStudio.SDK.Analyzers" version="15.8.33" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.8.122" targetFramework="net46" />
-  <package id="Microsoft.VSSDK.BuildTools" version="17.0.1619-preview1" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="17.0.5232" targetFramework="net46" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Fixes # 3431

## Description
This PR updates the **_dotnet templates_** removing the netcore2.1 and netcore2.2 options for creating bots.
Also, it updates the version of `Microsoft.VSSDK.BuildTools` to a stable version in the **_BotBuilderTemplatesVSIX_** project.

### Detailed Changes
- Updated the following templates removing netcore2.1 and netcore2.2:
   - Microsoft.BotFramework.CSharp.CoreBot
   - Microsoft.BotFramework.CSharp.EchoBot
   - Microsoft.BotFramework.CSharp.EmptyBot

- Updated the version of `Microsoft.VSSDK.BuildTools` to 17.0.5232 in the _BotBuilderTemplatesVSIX.csproj_ and _packages.config_


## Testing
These images show the VSIX working in VisualStudio 2019 and VisualStudio 202, and the before and after of the dotnet templates' menu.
![image](https://user-images.githubusercontent.com/44245136/144492814-95c51db0-8294-4147-8618-48d9f04b3d9e.png)
![image](https://user-images.githubusercontent.com/44245136/144493043-37b08e83-b001-424a-854f-e6f1461ec128.png)

![image](https://user-images.githubusercontent.com/44245136/144492875-daae22c7-7637-4fa1-8fcb-48537dfb4df2.png)
