### PR TITLE
[#3740] Update dotnet samples to target Net 6

### DIFF
--- a/samples/csharp_dotnetcore/01.console-echo/Console-EchoBot.csproj
+++ b/samples/csharp_dotnetcore/01.console-echo/Console-EchoBot.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/01.console-echo/README.md
+++ b/samples/csharp_dotnetcore/01.console-echo/README.md
@@ -8,7 +8,7 @@ This sample shows a simple echo bot and demonstrates the bot working as a consol
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/01.console-echo/README.md
+++ b/samples/csharp_dotnetcore/01.console-echo/README.md
@@ -8,7 +8,7 @@ This sample shows a simple echo bot and demonstrates the bot working as a consol
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/02.echo-bot/EchoBot.csproj
+++ b/samples/csharp_dotnetcore/02.echo-bot/EchoBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/02.echo-bot/README.md
+++ b/samples/csharp_dotnetcore/02.echo-bot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/02.echo-bot/README.md
+++ b/samples/csharp_dotnetcore/02.echo-bot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/03.welcome-user/README.md
+++ b/samples/csharp_dotnetcore/03.welcome-user/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/03.welcome-user/README.md
+++ b/samples/csharp_dotnetcore/03.welcome-user/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/03.welcome-user/WelcomeUser.csproj
+++ b/samples/csharp_dotnetcore/03.welcome-user/WelcomeUser.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/MultiTurnPromptBot.csproj
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/MultiTurnPromptBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/README.md
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/README.md
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/06.using-cards/CardsBot.csproj
+++ b/samples/csharp_dotnetcore/06.using-cards/CardsBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/06.using-cards/README.md
+++ b/samples/csharp_dotnetcore/06.using-cards/README.md
@@ -7,7 +7,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/06.using-cards/README.md
+++ b/samples/csharp_dotnetcore/06.using-cards/README.md
@@ -7,7 +7,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/AdaptiveCardsBot.csproj
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/AdaptiveCardsBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/README.md
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/README.md
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/08.suggested-actions/README.md
+++ b/samples/csharp_dotnetcore/08.suggested-actions/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/08.suggested-actions/README.md
+++ b/samples/csharp_dotnetcore/08.suggested-actions/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/08.suggested-actions/SuggestedActionsBot.csproj
+++ b/samples/csharp_dotnetcore/08.suggested-actions/SuggestedActionsBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/11.qnamaker/QnABot.csproj
+++ b/samples/csharp_dotnetcore/11.qnamaker/QnABot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/11.qnamaker/README.md
+++ b/samples/csharp_dotnetcore/11.qnamaker/README.md
@@ -19,7 +19,7 @@ This samples **requires** prerequisites in order to run.
 
 - This bot uses [QnA Maker Service](https://www.qnamaker.ai), an AI based cognitive service, to implement simple Question and Answer conversational patterns.
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/11.qnamaker/README.md
+++ b/samples/csharp_dotnetcore/11.qnamaker/README.md
@@ -19,7 +19,7 @@ This samples **requires** prerequisites in order to run.
 
 - This bot uses [QnA Maker Service](https://www.qnamaker.ai), an AI based cognitive service, to implement simple Question and Answer conversational patterns.
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/12.customQABot/CustomQABot.csproj
+++ b/samples/csharp_dotnetcore/12.customQABot/CustomQABot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/13.core-bot.tests/CoreBot.Tests.csproj
+++ b/samples/csharp_dotnetcore/13.core-bot.tests/CoreBot.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/samples/csharp_dotnetcore/13.core-bot/CoreBot.csproj
+++ b/samples/csharp_dotnetcore/13.core-bot/CoreBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/13.core-bot/README.md
+++ b/samples/csharp_dotnetcore/13.core-bot/README.md
@@ -19,7 +19,7 @@ This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to imp
 
 ### Install .NET Core CLI
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/13.core-bot/README.md
+++ b/samples/csharp_dotnetcore/13.core-bot/README.md
@@ -19,7 +19,7 @@ This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to imp
 
 ### Install .NET Core CLI
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/14.nlp-with-orchestrator/NLP-With-Orchestrator.csproj
+++ b/samples/csharp_dotnetcore/14.nlp-with-orchestrator/NLP-With-Orchestrator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Platforms>x64</Platforms>
   </PropertyGroup>

--- a/samples/csharp_dotnetcore/14.nlp-with-orchestrator/README.md
+++ b/samples/csharp_dotnetcore/14.nlp-with-orchestrator/README.md
@@ -24,7 +24,7 @@ This bot uses Orchestrator to route user utterances to multiple LUIS models and 
 This sample **requires** prerequisites in order to run.
 - Install latest supported version of [Visual C++ Redistributable](https://support.microsoft.com/en-gb/help/2977003/the-latest-supported-visual-c-downloads)
 - Install latest [Bot Framework Emulator](https://github.com/microsoft/BotFramework-Emulator/releases)
-- [.NET Core SDK](https://aka.ms/dotnet-core-applaunch?framework=Microsoft.AspNetCore.App&framework_version=3.1.0&arch=x64&rid=win10-x64) version 6.0
+- [.NET SDK](https://aka.ms/dotnet-core-applaunch?framework=Microsoft.AspNetCore.App&framework_version=3.1.0&arch=x64&rid=win10-x64) version 6.0
   
   ```bash
   > dotnet --version

--- a/samples/csharp_dotnetcore/14.nlp-with-orchestrator/README.md
+++ b/samples/csharp_dotnetcore/14.nlp-with-orchestrator/README.md
@@ -24,7 +24,7 @@ This bot uses Orchestrator to route user utterances to multiple LUIS models and 
 This sample **requires** prerequisites in order to run.
 - Install latest supported version of [Visual C++ Redistributable](https://support.microsoft.com/en-gb/help/2977003/the-latest-supported-visual-c-downloads)
 - Install latest [Bot Framework Emulator](https://github.com/microsoft/BotFramework-Emulator/releases)
-- [.NET Core SDK](https://aka.ms/dotnet-core-applaunch?framework=Microsoft.AspNetCore.App&framework_version=3.1.0&arch=x64&rid=win10-x64) version 3.1
+- [.NET Core SDK](https://aka.ms/dotnet-core-applaunch?framework=Microsoft.AspNetCore.App&framework_version=3.1.0&arch=x64&rid=win10-x64) version 6.0
   
   ```bash
   > dotnet --version

--- a/samples/csharp_dotnetcore/15.handling-attachments/HandlingAttachmentsBot.csproj
+++ b/samples/csharp_dotnetcore/15.handling-attachments/HandlingAttachmentsBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/15.handling-attachments/README.md
+++ b/samples/csharp_dotnetcore/15.handling-attachments/README.md
@@ -9,7 +9,7 @@ upload files to Teams from a bot and how to receive a file sent to a bot as an a
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/15.handling-attachments/README.md
+++ b/samples/csharp_dotnetcore/15.handling-attachments/README.md
@@ -9,7 +9,7 @@ upload files to Teams from a bot and how to receive a file sent to a bot as an a
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/16.proactive-messages/ProactiveBot.csproj
+++ b/samples/csharp_dotnetcore/16.proactive-messages/ProactiveBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/16.proactive-messages/README.md
+++ b/samples/csharp_dotnetcore/16.proactive-messages/README.md
@@ -15,7 +15,7 @@ all users who have previously messaged the bot.
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/16.proactive-messages/README.md
+++ b/samples/csharp_dotnetcore/16.proactive-messages/README.md
@@ -15,7 +15,7 @@ all users who have previously messaged the bot.
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/17.multilingual-bot/MultiLingualBot.csproj
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/MultiLingualBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/17.multilingual-bot/README.md
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/README.md
@@ -19,7 +19,7 @@ The API uses the most modern neural machine translation technology, as well as o
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/17.multilingual-bot/README.md
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/README.md
@@ -19,7 +19,7 @@ The API uses the most modern neural machine translation technology, as well as o
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/18.bot-authentication/AuthenticationBot.csproj
+++ b/samples/csharp_dotnetcore/18.bot-authentication/AuthenticationBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/18.bot-authentication/README.md
+++ b/samples/csharp_dotnetcore/18.bot-authentication/README.md
@@ -10,7 +10,7 @@ NOTE: Microsoft Teams currently differs slightly in the way auth is integrated w
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/18.bot-authentication/README.md
+++ b/samples/csharp_dotnetcore/18.bot-authentication/README.md
@@ -10,7 +10,7 @@ NOTE: Microsoft Teams currently differs slightly in the way auth is integrated w
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/19.custom-dialogs/Custom-Dialogs.csproj
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/Custom-Dialogs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/19.custom-dialogs/README.md
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/README.md
@@ -8,7 +8,7 @@ BotFramework provides a built-in base class called `Dialog`. By subclassing `Dia
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/19.custom-dialogs/README.md
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/README.md
@@ -8,7 +8,7 @@ BotFramework provides a built-in base class called `Dialog`. By subclassing `Dia
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/CoreBot-App-Insights.csproj
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/CoreBot-App-Insights.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/README.md
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/README.md
@@ -21,7 +21,7 @@ and [Application Insights](https://docs.microsoft.com/azure/azure-monitor/app/cl
 
 ### Install .NET Core CLI
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/README.md
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/README.md
@@ -21,7 +21,7 @@ and [Application Insights](https://docs.microsoft.com/azure/azure-monitor/app/cl
 
 ### Install .NET Core CLI
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/23.facebook-events/Facebook-Events-Bot.csproj
+++ b/samples/csharp_dotnetcore/23.facebook-events/Facebook-Events-Bot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/23.facebook-events/README.md
+++ b/samples/csharp_dotnetcore/23.facebook-events/README.md
@@ -8,7 +8,7 @@ More information about configuring a bot for Facebook Messenger can be found her
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/23.facebook-events/README.md
+++ b/samples/csharp_dotnetcore/23.facebook-events/README.md
@@ -8,7 +8,7 @@ More information about configuring a bot for Facebook Messenger can be found her
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/BotAuthenticationMSGraph.csproj
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/BotAuthenticationMSGraph.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/README.md
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/README.md
@@ -13,7 +13,7 @@ NOTE: Microsoft Teams currently differs slightly in the way auth is integrated w
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/README.md
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/README.md
@@ -13,7 +13,7 @@ NOTE: Microsoft Teams currently differs slightly in the way auth is integrated w
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/25.message-reaction/MessageReaction.csproj
+++ b/samples/csharp_dotnetcore/25.message-reaction/MessageReaction.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/25.message-reaction/README.md
+++ b/samples/csharp_dotnetcore/25.message-reaction/README.md
@@ -7,7 +7,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/25.message-reaction/README.md
+++ b/samples/csharp_dotnetcore/25.message-reaction/README.md
@@ -7,7 +7,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/40.timex-resolution/Timex-Resolution.csproj
+++ b/samples/csharp_dotnetcore/40.timex-resolution/Timex-Resolution.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/samples/csharp_dotnetcore/42.scaleout/README.md
+++ b/samples/csharp_dotnetcore/42.scaleout/README.md
@@ -8,7 +8,7 @@ The custom storage solution is implemented against memory for testing purposes a
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/42.scaleout/README.md
+++ b/samples/csharp_dotnetcore/42.scaleout/README.md
@@ -8,7 +8,7 @@ The custom storage solution is implemented against memory for testing purposes a
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/42.scaleout/ScaleoutBot.csproj
+++ b/samples/csharp_dotnetcore/42.scaleout/ScaleoutBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/43.complex-dialog/ComplexDialogBot.csproj
+++ b/samples/csharp_dotnetcore/43.complex-dialog/ComplexDialogBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/43.complex-dialog/README.md
+++ b/samples/csharp_dotnetcore/43.complex-dialog/README.md
@@ -4,7 +4,7 @@ This sample creates a complex conversation with dialogs.
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/43.complex-dialog/README.md
+++ b/samples/csharp_dotnetcore/43.complex-dialog/README.md
@@ -4,7 +4,7 @@ This sample creates a complex conversation with dialogs.
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/PromptUsersForInput.csproj
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/PromptUsersForInput.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/README.md
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/README.md
@@ -6,7 +6,7 @@ The bot maintains user state to track the user's answers.
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/README.md
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/README.md
@@ -6,7 +6,7 @@ The bot maintains user state to track the user's answers.
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/45.state-management/StateMangementBot.csproj
+++ b/samples/csharp_dotnetcore/45.state-management/StateMangementBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/46.teams-auth/README.md
+++ b/samples/csharp_dotnetcore/46.teams-auth/README.md
@@ -19,7 +19,7 @@ This sample utilizes an app setting `UseSingleSignOn` to add `TeamsSSOTokenExcha
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account (not a guest account)
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/46.teams-auth/README.md
+++ b/samples/csharp_dotnetcore/46.teams-auth/README.md
@@ -19,7 +19,7 @@ This sample utilizes an app setting `UseSingleSignOn` to add `TeamsSSOTokenExcha
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account (not a guest account)
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/46.teams-auth/TeamsAuth.csproj
+++ b/samples/csharp_dotnetcore/46.teams-auth/TeamsAuth.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/47.inspection/Inspection.csproj
+++ b/samples/csharp_dotnetcore/47.inspection/Inspection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/47.inspection/README.md
+++ b/samples/csharp_dotnetcore/47.inspection/README.md
@@ -12,7 +12,7 @@ More details are available [here](https://github.com/microsoft/BotFramework-Emul
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/47.inspection/README.md
+++ b/samples/csharp_dotnetcore/47.inspection/README.md
@@ -12,7 +12,7 @@ More details are available [here](https://github.com/microsoft/BotFramework-Emul
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/48.customQABot-all-features/CustomQABotAllFeatures.csproj
+++ b/samples/csharp_dotnetcore/48.customQABot-all-features/CustomQABotAllFeatures.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/QnABotAllFeatures.csproj
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/QnABotAllFeatures.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/README.md
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/README.md
@@ -8,7 +8,7 @@ build a Search-based Messaging Extension.
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/README.md
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/README.md
@@ -8,7 +8,7 @@ build a Search-based Messaging Extension.
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/TeamsMessagingExtensionsSearch.csproj
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/TeamsMessagingExtensionsSearch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/README.md
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/README.md
@@ -8,7 +8,7 @@ build an Action-based Messaging Extension.
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/README.md
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/README.md
@@ -8,7 +8,7 @@ build an Action-based Messaging Extension.
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/TeamsMessagingExtensionsAction.csproj
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/TeamsMessagingExtensionsAction.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/README.md
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/README.md
@@ -15,7 +15,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## Description

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/README.md
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/README.md
@@ -15,7 +15,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## Description

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsMessagingExtensionsSearchAuthConfig.csproj
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsMessagingExtensionsSearchAuthConfig.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/README.md
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/README.md
@@ -9,7 +9,7 @@ This Messaging Extension has been created using [Bot Framework](https://dev.botf
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/README.md
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/README.md
@@ -9,7 +9,7 @@ This Messaging Extension has been created using [Bot Framework](https://dev.botf
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/TeamsMessagingExtensionsActionPreview.csproj
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/TeamsMessagingExtensionsActionPreview.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/54.teams-task-module/README.md
+++ b/samples/csharp_dotnetcore/54.teams-task-module/README.md
@@ -7,7 +7,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com). I
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/54.teams-task-module/README.md
+++ b/samples/csharp_dotnetcore/54.teams-task-module/README.md
@@ -7,7 +7,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com). I
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/54.teams-task-module/TeamsTaskModule.csproj
+++ b/samples/csharp_dotnetcore/54.teams-task-module/TeamsTaskModule.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/55.teams-link-unfurling/README.md
+++ b/samples/csharp_dotnetcore/55.teams-link-unfurling/README.md
@@ -7,7 +7,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/55.teams-link-unfurling/README.md
+++ b/samples/csharp_dotnetcore/55.teams-link-unfurling/README.md
@@ -7,7 +7,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/55.teams-link-unfurling/TeamsLinkUnfurling.csproj
+++ b/samples/csharp_dotnetcore/55.teams-link-unfurling/TeamsLinkUnfurling.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/56.teams-file-upload/README.md
+++ b/samples/csharp_dotnetcore/56.teams-file-upload/README.md
@@ -8,7 +8,7 @@ upload files to Teams from a bot and how to receive a file sent to a bot as an a
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/56.teams-file-upload/README.md
+++ b/samples/csharp_dotnetcore/56.teams-file-upload/README.md
@@ -8,7 +8,7 @@ upload files to Teams from a bot and how to receive a file sent to a bot as an a
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/56.teams-file-upload/TeamsFileUpload.csproj
+++ b/samples/csharp_dotnetcore/56.teams-file-upload/TeamsFileUpload.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
@@ -9,7 +9,7 @@ how to incorporate basic conversational flow into a Teams application. It also i
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
@@ -9,7 +9,7 @@ how to incorporate basic conversational flow into a Teams application. It also i
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/TeamsConversationBot.csproj
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/TeamsConversationBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/README.md
+++ b/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/README.md
@@ -8,7 +8,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com). T
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/README.md
+++ b/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/README.md
@@ -8,7 +8,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com). T
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/TeamsStartNewThreadInTeam.csproj
+++ b/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/TeamsStartNewThreadInTeam.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/EchoSkillBot.csproj
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/EchoSkillBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.EchoSkillBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.EchoSkillBot</RootNamespace>

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/SimpleRootBot.csproj
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/SimpleRootBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.SimpleRootBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.SimpleRootBot</RootNamespace>

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DialogRootBot.csproj
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DialogRootBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.DialogRootBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.DialogRootBot</RootNamespace>

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DialogSkillBot.csproj
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DialogSkillBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.DialogSkillBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.DialogSkillBot</RootNamespace>

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/README.md
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/README.md
@@ -6,7 +6,7 @@ This bot has been created using the [Bot Framework](https://dev.botframework.com
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/README.md
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/README.md
@@ -6,7 +6,7 @@ This bot has been created using the [Bot Framework](https://dev.botframework.com
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/README.md
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/README.md
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/RootBot.csproj
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/RootBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.RootBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.RootBot</RootNamespace>

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/SkillBot/SkillBot.csproj
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/SkillBot/SkillBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.SkillBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.SkillBot</RootNamespace>


### PR DESCRIPTION
Addresses # 3740
#minor

## Description
This PR updates the BotBuilder samples to target .NET6

## Specific Changes
- Updated the following samples to target .NET6
  - Console-echo
  - Echo-bot
  - Welcome-user
  - Multi-turn-prompt
  - Using-cards
  - Using-adaptive-cards
  - Suggested-actions
  - QnAmaker
  - CustomQABot
  - Core-bot
  - Npl-with-orchestrator
  - Handling-attachments
  - Proactive-messages
  - Multilingual-bot
  - Custom-dialogs
  - Corebot-app-insights
  - Facebook-events
  - Bot-authentication-msgraph
  - Message-reaction
  - Timex-resolution
  - Scaleout
  - Completx-dialog
  - Prompt-users-for-input
  - State-management
  - Teams-auth
  - Inspection
  - CustomQABot-all-features
  - QnAmaker-all-features
  - Teams-messaging-extensions-search
  - Teams-messaging-extensions-action
  - Teams-messaging-extensions-search-auth-config
  - Teams-messaging-extensions-action-preview
  - Teams-task-module
  - Teams-link-unfurling
  - Teams-file-upload
  - Teams-conversation-bot
  - Teams-start-new-thread-in-channel
  - Skills-simple-bot-to-bot
  - Skills-skilldialog
  - Skills-sso-cloudadapter
- README files updated to target .NET6

## Testing

_Successful build_
<img width="396" alt="image (74)" src="https://user-images.githubusercontent.com/64815358/167668296-982a2a6d-652a-457f-afe8-a8aa8247d51c.png">

