### PR TITLE
[#3740] Update dotnet samples to target Net 6 - QnA maker samples

### DIFF
--- a/samples/csharp_dotnetcore/11.qnamaker/QnABot.csproj
+++ b/samples/csharp_dotnetcore/11.qnamaker/QnABot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/11.qnamaker/README.md
+++ b/samples/csharp_dotnetcore/11.qnamaker/README.md
@@ -19,7 +19,7 @@ This samples **requires** prerequisites in order to run.
 
 - This bot uses [QnA Maker Service](https://www.qnamaker.ai), an AI based cognitive service, to implement simple Question and Answer conversational patterns.
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/12.customQABot/CustomQABot.csproj
+++ b/samples/csharp_dotnetcore/12.customQABot/CustomQABot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/48.customQABot-all-features/CustomQABotAllFeatures.csproj
+++ b/samples/csharp_dotnetcore/48.customQABot-all-features/CustomQABotAllFeatures.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/QnABotAllFeatures.csproj
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/QnABotAllFeatures.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/README.md
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/README.md
@@ -133,7 +133,7 @@ If you are new to Microsoft Azure, please refer to [Getting started with Azure][
 
 [1]: https://dev.botframework.com
 [2]: https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-relnotes
-[3]: https://dotnet.microsoft.com/download/dotnet-core/3.1
+[3]: https://dotnet.microsoft.com/en-us/download
 [4]: https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0
 [5]: https://github.com/microsoft/botframework-emulator
 [6]: https://aka.ms/botframeworkemulator


### PR DESCRIPTION
Addresses # 3740
#minor

## Description
This PR updates the QnA maker samples to target .NET6

## Specific Changes
- Updated the following samples to target .NET6
  - CustomQABot
  - CustomQABotAllFeatures
  - QnABot
  - QnABotAllFeatures
- README files updated to target .NET6


## Testing
CustomQABot working
![image (83)](https://user-images.githubusercontent.com/64815358/168362934-25650535-b829-41db-8b42-84f0e1d62f23.png)

CustomQABotAllFeatures working
<img width="475" alt="image (84)" src="https://user-images.githubusercontent.com/64815358/168363304-0e6ca6c8-9586-4c6b-94d4-f9d58298d1eb.png">

QnABot working
<img width="292" alt="image" src="https://user-images.githubusercontent.com/64815358/168374785-009cb632-7feb-49ce-8d41-cb1f0067a852.png">

QnABotAllFeatures working
![image (88)](https://user-images.githubusercontent.com/64815358/168374340-94ef5339-2bb6-4eda-a98b-b8e6be1ac1ff.png)

