### PR TITLE
[#3740] Update dotnet samples to target Net 6 - Teams samples

### DIFF
--- a/samples/csharp_dotnetcore/25.message-reaction/MessageReaction.csproj
+++ b/samples/csharp_dotnetcore/25.message-reaction/MessageReaction.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/25.message-reaction/README.md
+++ b/samples/csharp_dotnetcore/25.message-reaction/README.md
@@ -7,7 +7,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/46.teams-auth/README.md
+++ b/samples/csharp_dotnetcore/46.teams-auth/README.md
@@ -19,7 +19,7 @@ This sample utilizes an app setting `UseSingleSignOn` to add `TeamsSSOTokenExcha
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account (not a guest account)
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/46.teams-auth/TeamsAuth.csproj
+++ b/samples/csharp_dotnetcore/46.teams-auth/TeamsAuth.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/README.md
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/README.md
@@ -8,7 +8,7 @@ build a Search-based Messaging Extension.
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/TeamsMessagingExtensionsSearch.csproj
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/TeamsMessagingExtensionsSearch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/README.md
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/README.md
@@ -8,7 +8,7 @@ build an Action-based Messaging Extension.
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/TeamsMessagingExtensionsAction.csproj
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/TeamsMessagingExtensionsAction.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/README.md
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/README.md
@@ -15,7 +15,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## Description

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsMessagingExtensionsSearchAuthConfig.csproj
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsMessagingExtensionsSearchAuthConfig.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/README.md
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/README.md
@@ -9,7 +9,7 @@ This Messaging Extension has been created using [Bot Framework](https://dev.botf
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/TeamsMessagingExtensionsActionPreview.csproj
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/TeamsMessagingExtensionsActionPreview.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/54.teams-task-module/README.md
+++ b/samples/csharp_dotnetcore/54.teams-task-module/README.md
@@ -7,7 +7,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com). I
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/54.teams-task-module/TeamsTaskModule.csproj
+++ b/samples/csharp_dotnetcore/54.teams-task-module/TeamsTaskModule.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/55.teams-link-unfurling/README.md
+++ b/samples/csharp_dotnetcore/55.teams-link-unfurling/README.md
@@ -7,7 +7,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/55.teams-link-unfurling/TeamsLinkUnfurling.csproj
+++ b/samples/csharp_dotnetcore/55.teams-link-unfurling/TeamsLinkUnfurling.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/56.teams-file-upload/README.md
+++ b/samples/csharp_dotnetcore/56.teams-file-upload/README.md
@@ -8,7 +8,7 @@ upload files to Teams from a bot and how to receive a file sent to a bot as an a
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/56.teams-file-upload/TeamsFileUpload.csproj
+++ b/samples/csharp_dotnetcore/56.teams-file-upload/TeamsFileUpload.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
@@ -9,7 +9,7 @@ how to incorporate basic conversational flow into a Teams application. It also i
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/TeamsConversationBot.csproj
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/TeamsConversationBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/README.md
+++ b/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/README.md
@@ -8,7 +8,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com). T
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/TeamsStartNewThreadInTeam.csproj
+++ b/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/TeamsStartNewThreadInTeam.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Addresses # 3740
#minor

## Description
This PR updates the Teams samples to target .NET6

## Specific Changes
- Updated the following samples to target .NET6
  - Message reaction
  - Teams-auth
  - Teams-messaging-extensions-search
  - Teams-messaging-extensions-action
  - Teams-messaging-extensions-search-auth-config
  - Teams-messaging-extensions-action-preview
  - Teams-task-module
  - Teams-link-unfurling
  - Teams-file-upload
  - Teams-conversation-bot
  - Teams-start-new-thread-in-channel
- README files updated to target .NET6


## Testing
Teams samples working
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/64815358/168373474-fd96846a-9dc5-4e60-8e5e-47ff0e444b28.png">

