### PR TITLE
[#3740] Update dotnet samples to target Net 6 - Skills samples

### DIFF
--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/EchoSkillBot.csproj
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/EchoSkillBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.EchoSkillBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.EchoSkillBot</RootNamespace>

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/SimpleRootBot.csproj
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/SimpleRootBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.SimpleRootBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.SimpleRootBot</RootNamespace>

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DialogRootBot.csproj
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DialogRootBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.DialogRootBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.DialogRootBot</RootNamespace>

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DialogSkillBot.csproj
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DialogSkillBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.DialogSkillBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.DialogSkillBot</RootNamespace>

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/README.md
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/README.md
@@ -6,7 +6,7 @@ This bot has been created using the [Bot Framework](https://dev.botframework.com
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/README.md
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/RootBot.csproj
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/RootBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.RootBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.RootBot</RootNamespace>

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/SkillBot/SkillBot.csproj
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/SkillBot/SkillBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.SkillBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.SkillBot</RootNamespace>


### PR DESCRIPTION
Addresses # 3740
#minor

## Description
This PR updates the Skills samples to target .NET6

## Specific Changes
- Updated the following samples to target .NET6
  - Skills-simple-bot-to-bot
  - Skills-skilldialog
  - Skills-sso-cloudadapter
- README files updated to target .NET6


## Testing
These images show the updated bots working as expected.
![image](https://user-images.githubusercontent.com/44245136/168341649-a18b953c-0014-41a4-bdc4-c2e3187ec5ea.png)