### PR TITLE
[#3286] Add linting checks to CI - DotNet

### DIFF
--- a/.github/workflows/ci-dotnet-samples.yml
+++ b/.github/workflows/ci-dotnet-samples.yml
@@ -44,9 +44,8 @@ jobs:
 
           $paths = @("${{ env.GIT_DIFF_FILTERED }}" -replace "'", "" -split " ")
           $rootFolder = "${{ env.ROOT_FOLDER }}"
-          $pkg = "appsettings.json"
 
-          $result = $paths | ForEach-Object { UpSearchFolder -path $_ -file $pkg } | Get-Unique | ForEach-Object {
+          $result = $paths | ForEach-Object { UpSearchFolder -path $_ -file "*.csproj" } | Get-Unique | ForEach-Object {
             $folder = $_
             return @{ 
               name = $folder.Substring($folder.IndexOf($rootFolder) + $rootFolder.Length);

--- a/.github/workflows/ci-dotnet-samples.yml
+++ b/.github/workflows/ci-dotnet-samples.yml
@@ -1,0 +1,87 @@
+name: ci-dotnet-samples
+
+env:
+  ROOT_FOLDER: BotBuilder-Samples/samples/
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "samples/**/*.cs"
+
+jobs:
+  generate:
+    name: detect and generate bot matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: git diff
+        uses: technote-space/get-diff-action@v4
+        with:
+          PATTERNS: samples/**/*.cs
+          ABSOLUTE: true
+
+      - name: generate matrix
+        id: set-matrix
+        shell: pwsh
+        if: env.GIT_DIFF
+        run: |
+          function UpSearchFolder {
+            param ([String] $path, [String] $file)
+
+            while ($path -and !(Test-Path (Join-Path $path $file))) {
+              $path = Split-Path $path -Parent
+            }
+
+            return $path
+          }
+
+          $paths = @("${{ env.GIT_DIFF_FILTERED }}" -replace "'", "" -split " ")
+          $rootFolder = "${{ env.ROOT_FOLDER }}"
+          $pkg = "appsettings.json"
+
+          $result = $paths | ForEach-Object { UpSearchFolder -path $_ -file $pkg } | Get-Unique | ForEach-Object {
+            $folder = $_
+            return @{ 
+              name = $folder.Substring($folder.IndexOf($rootFolder) + $rootFolder.Length);
+              folder = $folder;
+            } 
+          }
+
+          "Generated matrix:"
+          ConvertTo-Json @($result)
+
+          $matrix = ConvertTo-Json -Compress @($result)
+
+          echo "::set-output name=matrix::$($matrix)"
+
+  build:
+    needs: generate
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include: ${{fromJSON(needs.generate.outputs.matrix)}}
+      fail-fast: false
+
+    name: bot - ${{ matrix.name }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: use .net 6.0.x
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: "6.0.x"
+
+      - name: dotnet restore
+        run: dotnet restore
+        working-directory: ${{ matrix.folder }}
+
+      - name: dotnet build
+        run: dotnet build --configuration Release --no-restore --nologo --clp:NoSummary
+        working-directory: ${{ matrix.folder }}


### PR DESCRIPTION
Addresses # 3286

## Description
This PR adds the new `ci-dotnet-samples.yml` pipeline to the GitHub `workflow` process, including the steps to detect and identify the modified files from a PR, generating a matrix that includes the steps to install, restore and lint each bot.

### Detailed Changes
- Adding the new `ci-dotnet-samples.yml` pipeline into the GitHub workflows.
- The pipeline is separated into two main jobs:
  - `generate`: Will search all `.cs` files modified in the PR, and categorize them, generating the bot matrix.
  - `build`: Will create jobs based on the generated matrix, and for each bot's job will execute the `install` .NET 6, `build` and `lint` commands.

## Testing
The following images show when the checks fail and when they pass.
![imagen](https://user-images.githubusercontent.com/62260472/172477508-81046b9a-0293-4e74-8ac0-586cb9b1ec5b.png)
![imagen](https://user-images.githubusercontent.com/62260472/172477517-fcf60328-91cf-4d19-85da-efdce8402f13.png)