### PR TITLE
[Node]Update node version to 16 in ARM templates

### DIFF
--- a/Migration/Dispatch/csharp/14.nlp-with-dispatch/DeploymentTemplates/template-with-new-rg.json
+++ b/Migration/Dispatch/csharp/14.nlp-with-dispatch/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/Migration/Dispatch/csharp/14.nlp-with-dispatch/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/Migration/Dispatch/csharp/14.nlp-with-dispatch/DeploymentTemplates/template-with-preexisting-rg.json
@@ -107,7 +107,7 @@
                     "appSettings": [
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "10.14.1"
+                            "value": "~16"
                         },
                         {
                             "name": "MicrosoftAppId",

--- a/Migration/Dispatch/javascript/14.nlp-with-dispatch/deploymentTemplates/template-with-new-rg.json
+++ b/Migration/Dispatch/javascript/14.nlp-with-dispatch/deploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/Migration/Dispatch/javascript/14.nlp-with-dispatch/deploymentTemplates/template-with-preexisting-rg.json
+++ b/Migration/Dispatch/javascript/14.nlp-with-dispatch/deploymentTemplates/template-with-preexisting-rg.json
@@ -107,7 +107,7 @@
                     "appSettings": [
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "10.14.1"
+                            "value": "~16"
                         },
                         {
                             "name": "MicrosoftAppId",

--- a/Migration/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-new-rg.json
+++ b/Migration/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/Migration/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/Migration/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -107,7 +107,7 @@
                     "appSettings": [
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "10.14.1"
+                            "value": "~16"
                         },
                         {
                             "name": "MicrosoftAppId",

--- a/Migration/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-new-rg.json
+++ b/Migration/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/Migration/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-preexisting-rg.json
+++ b/Migration/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-preexisting-rg.json
@@ -107,7 +107,7 @@
                     "appSettings": [
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "10.14.1"
+                            "value": "~16"
                         },
                         {
                             "name": "MicrosoftAppId",

--- a/archive/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/14.nlp-with-orchestrator/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/14.nlp-with-orchestrator/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/14.nlp-with-orchestrator/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/14.nlp-with-orchestrator/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/25.message-reaction/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/25.message-reaction/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/25.message-reaction/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/25.message-reaction/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/49.qnamaker-all-features/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/49.qnamaker-all-features/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/49.qnamaker-all-features/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/49.qnamaker-all-features/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/54.teams-task-module/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/54.teams-task-module/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/54.teams-task-module/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/54.teams-task-module/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/55.teams-link-unfurling/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/55.teams-link-unfurling/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/55.teams-link-unfurling/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/55.teams-link-unfurling/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/56.teams-file-upload/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/56.teams-file-upload/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/56.teams-file-upload/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/56.teams-file-upload/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/57.teams-conversation-bot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/57.teams-conversation-bot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/57.teams-conversation-bot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/57.teams-conversation-bot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/11.qnamaker/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/11.qnamaker/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/11.qnamaker/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/11.qnamaker/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/14.nlp-with-orchestrator/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/14.nlp-with-orchestrator/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/14.nlp-with-orchestrator/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/14.nlp-with-orchestrator/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/25.message-reaction/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/25.message-reaction/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/25.message-reaction/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/25.message-reaction/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/49.qnamaker-all-features/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/49.qnamaker-all-features/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/49.qnamaker-all-features/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/49.qnamaker-all-features/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/54.teams-task-module/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/54.teams-task-module/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/54.teams-task-module/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/54.teams-task-module/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/55.teams-link-unfurling/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/55.teams-link-unfurling/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/55.teams-link-unfurling/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/55.teams-link-unfurling/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/56.teams-file-upload/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/56.teams-file-upload/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/56.teams-file-upload/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/56.teams-file-upload/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/57.teams-conversation-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/57.teams-conversation-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/57.teams-conversation-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/57.teams-conversation-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/typescript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/typescript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/typescript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/typescript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/typescript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/typescript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/typescript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/typescript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/typescript_nodejs/57.teams-conversation-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/typescript_nodejs/57.teams-conversation-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/typescript_nodejs/57.teams-conversation-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/typescript_nodejs/57.teams-conversation-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/archive/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/archive/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/archive/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/archive/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/composer-samples/csharp_dotnetcore/projects/AskingQuestionsSample/AskingQuestionsSample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/AskingQuestionsSample/AskingQuestionsSample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/AskingQuestionsSample/AskingQuestionsSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/AskingQuestionsSample/AskingQuestionsSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/ControllingConversationFlowSample/ControllingConversationFlowSample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/ControllingConversationFlowSample/ControllingConversationFlowSample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/ControllingConversationFlowSample/ControllingConversationFlowSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/ControllingConversationFlowSample/ControllingConversationFlowSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/CustomAction/CustomAction/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/CustomAction/CustomAction/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/CustomAction/CustomAction/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/CustomAction/CustomAction/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/CustomTrigger/CustomTrigger/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/CustomTrigger/CustomTrigger/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/CustomTrigger/CustomTrigger/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/CustomTrigger/CustomTrigger/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/EchoBot/EchoBot/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/EchoBot/EchoBot/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/EchoBot/EchoBot/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/EchoBot/EchoBot/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/InterruptionSample/InterruptionSample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/InterruptionSample/InterruptionSample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/InterruptionSample/InterruptionSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/InterruptionSample/InterruptionSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/OrchestratorDispatch/Scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/OrchestratorDispatch/Scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/OrchestratorDispatch/Scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/OrchestratorDispatch/Scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/OrchestratorSchoolNavigator/SchoolNavigator/Scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/QnAMakerLUISSample/QnAMakerLUISSample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/QnAMakerLUISSample/QnAMakerLUISSample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/QnAMakerLUISSample/QnAMakerLUISSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/QnAMakerLUISSample/QnAMakerLUISSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/QnASample/QnASample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/QnASample/QnASample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/QnASample/QnASample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/QnASample/QnASample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/RespondingWithCardsSample/RespondingWithCardsSample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/RespondingWithCardsSample/RespondingWithCardsSample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/RespondingWithCardsSample/RespondingWithCardsSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/RespondingWithCardsSample/RespondingWithCardsSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/RespondingWithTextSample/RespondingWithTextSample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/RespondingWithTextSample/RespondingWithTextSample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/RespondingWithTextSample/RespondingWithTextSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/RespondingWithTextSample/RespondingWithTextSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/ToDoBotWithLUISSample/ToDoBotWithLUISSample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/ToDoBotWithLUISSample/ToDoBotWithLUISSample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/ToDoBotWithLUISSample/ToDoBotWithLUISSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/ToDoBotWithLUISSample/ToDoBotWithLUISSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/TodoSample/TodoSample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/TodoSample/TodoSample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/csharp_dotnetcore/projects/TodoSample/TodoSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/csharp_dotnetcore/projects/TodoSample/TodoSample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/asking-questions-sample/askingquestionssample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/javascript_nodejs/projects/asking-questions-sample/askingquestionssample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/asking-questions-sample/askingquestionssample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/asking-questions-sample/askingquestionssample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/controlling-conversation-flow-sample/controllingconversationflowsample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/javascript_nodejs/projects/controlling-conversation-flow-sample/controllingconversationflowsample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/controlling-conversation-flow-sample/controllingconversationflowsample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/controlling-conversation-flow-sample/controllingconversationflowsample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/custom-action/customaction/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/javascript_nodejs/projects/custom-action/customaction/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/custom-action/customaction/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/custom-action/customaction/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/echo-bot/echobot/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/javascript_nodejs/projects/echo-bot/echobot/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/echo-bot/echobot/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/echo-bot/echobot/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/interruption-sample/interruptionsample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/javascript_nodejs/projects/interruption-sample/interruptionsample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/interruption-sample/interruptionsample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/interruption-sample/interruptionsample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/qna-maker-luis-sample/qnamakerluissample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/javascript_nodejs/projects/qna-maker-luis-sample/qnamakerluissample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/qna-maker-luis-sample/qnamakerluissample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/qna-maker-luis-sample/qnamakerluissample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/qna-sample/qnasample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/javascript_nodejs/projects/qna-sample/qnasample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/qna-sample/qnasample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/qna-sample/qnasample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/responding-with-cards-sample/respondingwithcardssample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/javascript_nodejs/projects/responding-with-cards-sample/respondingwithcardssample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/responding-with-cards-sample/respondingwithcardssample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/responding-with-cards-sample/respondingwithcardssample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/responding-with-text-sample/respondingwithtextsample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/javascript_nodejs/projects/responding-with-text-sample/respondingwithtextsample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/responding-with-text-sample/respondingwithtextsample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/responding-with-text-sample/respondingwithtextsample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/todo-bot-with-luis-sample/todobotwithluissample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/javascript_nodejs/projects/todo-bot-with-luis-sample/todobotwithluissample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/todo-bot-with-luis-sample/todobotwithluissample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/todo-bot-with-luis-sample/todobotwithluissample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/todo-sample/todosample/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/composer-samples/javascript_nodejs/projects/todo-sample/todosample/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/composer-samples/javascript_nodejs/projects/todo-sample/todosample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/composer-samples/javascript_nodejs/projects/todo-sample/todosample/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -188,7 +188,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppId",

--- a/experimental/immediate-accept-adapter/csharp_dotnetcore/DeploymentTemplates/template-with-new-rg.json
+++ b/experimental/immediate-accept-adapter/csharp_dotnetcore/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/experimental/immediate-accept-adapter/csharp_dotnetcore/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/immediate-accept-adapter/csharp_dotnetcore/DeploymentTemplates/template-with-preexisting-rg.json
@@ -107,7 +107,7 @@
                     "appSettings": [
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "10.14.1"
+                            "value": "~16"
                         },
                         {
                             "name": "MicrosoftAppId",

--- a/experimental/language-orchestrator/csharp_dotnetcore/DeploymentTemplates/template-with-new-rg.json
+++ b/experimental/language-orchestrator/csharp_dotnetcore/DeploymentTemplates/template-with-new-rg.json
@@ -194,7 +194,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppType",

--- a/experimental/language-orchestrator/csharp_dotnetcore/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/language-orchestrator/csharp_dotnetcore/DeploymentTemplates/template-with-preexisting-rg.json
@@ -170,7 +170,7 @@
                     "appSettings": [
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "10.14.1"
+                            "value": "~16"
                         },
                         {
                             "name": "MicrosoftAppType",

--- a/experimental/language-orchestrator/javascript_nodejs/deploymentTemplates/template-with-new-rg.json
+++ b/experimental/language-orchestrator/javascript_nodejs/deploymentTemplates/template-with-new-rg.json
@@ -194,7 +194,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppType",

--- a/experimental/language-orchestrator/javascript_nodejs/deploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/language-orchestrator/javascript_nodejs/deploymentTemplates/template-with-preexisting-rg.json
@@ -170,7 +170,7 @@
                     "appSettings": [
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "10.14.1"
+                            "value": "~16"
                         },
                         {
                             "name": "MicrosoftAppType",

--- a/experimental/sso-with-skills/RootBot/DeploymentTemplates/template-with-new-rg.json
+++ b/experimental/sso-with-skills/RootBot/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/experimental/sso-with-skills/RootBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/sso-with-skills/RootBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -114,7 +114,7 @@
                     "appSettings": [
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "10.14.1"
+                            "value": "~16"
                         },
                         {
                             "name": "MicrosoftAppId",

--- a/experimental/sso-with-skills/SkillBot/DeploymentTemplates/template-with-new-rg.json
+++ b/experimental/sso-with-skills/SkillBot/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                     "appSettings": [
                                         {
                                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
+                                            "value": "~16"
                                         },
                                         {
                                             "name": "MicrosoftAppId",

--- a/experimental/sso-with-skills/SkillBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/sso-with-skills/SkillBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -114,7 +114,7 @@
                     "appSettings": [
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "10.14.1"
+                            "value": "~16"
                         },
                         {
                             "name": "MicrosoftAppId",

--- a/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/Linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/Linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -182,7 +182,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/Linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/Linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -199,7 +199,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/03.welcome-user/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/03.welcome-user/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/03.welcome-user/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/03.welcome-user/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/06.using-cards/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/06.using-cards/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/06.using-cards/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/06.using-cards/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/08.suggested-actions/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/08.suggested-actions/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/08.suggested-actions/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/08.suggested-actions/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/12.customQABot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/12.customQABot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/12.customQABot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/12.customQABot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/Linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/Linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -182,7 +182,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/Linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/Linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -199,7 +199,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/17.multilingual-bot/DeploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/DeploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/17.multilingual-bot/DeploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/DeploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/19.custom-dialogs/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/19.custom-dialogs/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/23.facebook-events/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/23.facebook-events/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/23.facebook-events/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/23.facebook-events/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/42.scaleout/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/42.scaleout/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/42.scaleout/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/42.scaleout/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/43.complex-dialog/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/43.complex-dialog/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/43.complex-dialog/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/43.complex-dialog/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/45.state-management/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/45.state-management/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/45.state-management/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/45.state-management/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/47.inspection/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/47.inspection/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/47.inspection/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/47.inspection/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/48.customQABot-all-features/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/48.customQABot-all-features/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/48.customQABot-all-features/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/48.customQABot-all-features/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/SkillBot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/SkillBot/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/SkillBot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/SkillBot/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/84.bot-authentication-certificate/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/84.bot-authentication-certificate/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/84.bot-authentication-certificate/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/84.bot-authentication-certificate/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/85.bot-authentication-sni/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/csharp_dotnetcore/85.bot-authentication-sni/DeploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/csharp_dotnetcore/85.bot-authentication-sni/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/csharp_dotnetcore/85.bot-authentication-sni/DeploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/csharp_webapi/13.core-bot/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_webapi/13.core-bot/DeploymentTemplates/template-with-new-rg.json
@@ -131,7 +131,7 @@
                                   "appSettings": [
                                       {
                                           "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                          "value": "10.14.1"
+                                          "value": "~16"
                                       },
                                       {
                                           "name": "MicrosoftAppId",

--- a/samples/csharp_webapi/13.core-bot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_webapi/13.core-bot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -107,7 +107,7 @@
                   "appSettings": [
                       {
                           "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                          "value": "10.14.1"
+                          "value": "~16"
                       },
                       {
                           "name": "MicrosoftAppId",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16.20"
+      "defaultValue": "NODE|16"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|10.14"
+      "defaultValue": "NODE|16.20"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16.20"
+      "defaultValue": "NODE|16"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|10.14"
+      "defaultValue": "NODE|16.20"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16.20"
+      "defaultValue": "NODE|16"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|10.14"
+      "defaultValue": "NODE|16.20"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16.20"
+      "defaultValue": "NODE|16"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|10.14"
+      "defaultValue": "NODE|16.20"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16.20"
+      "defaultValue": "NODE|16"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|10.14"
+      "defaultValue": "NODE|16.20"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16.20"
+      "defaultValue": "NODE|16"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|10.14"
+      "defaultValue": "NODE|16.20"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -176,7 +176,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -176,7 +176,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -194,7 +194,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -194,7 +194,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16.20"
+      "defaultValue": "NODE|16"
     },
     "appId": {
       "type": "string",
@@ -151,7 +151,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|10.14"
+      "defaultValue": "NODE|16.20"
     },
     "appId": {
       "type": "string",
@@ -151,7 +151,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "16.20.2"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16.20"
+      "defaultValue": "NODE|16"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|10.14"
+      "defaultValue": "NODE|16.20"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "16.20.2"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/00.empty-bot/deploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/00.empty-bot/deploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/00.empty-bot/deploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/00.empty-bot/deploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|10.14"
+      "defaultValue": "NODE|16"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|10.14"
+      "defaultValue": "NODE|16"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/03.welcome-users/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/03.welcome-users/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/06.using-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/06.using-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|10.14"
+      "defaultValue": "NODE|16"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|10.14"
+      "defaultValue": "NODE|16"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/16.proactive-messages/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/16.proactive-messages/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
+              "value": "~16"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "10.14.1"
+                      "value": "~16"
                     },
                     {
                       "name": "MicrosoftAppType",


### PR DESCRIPTION
#minor 

## Description
This PR updates the default node version to 16 in the ARM templates of every Javascript sample.

## Proposed Changes
  - Updated the default node version to ~16 in the **_template-BotApp-new-rg.json_** files of node JS and TS samples.

## Testing
These images show the bot deployed with ARM templates working with node 16.
![image](https://github.com/southworks/BotBuilder-Samples/assets/122501764/f6332b9f-b6dc-44b4-8233-5af253304025)
![image](https://github.com/southworks/BotBuilder-Samples/assets/122501764/8a198404-fa63-485a-a508-6e250b2f261b)
