### PR TITLE
[#3948] Update dotnet samples to target .Net 8 - Skills samples

### DIFF
--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/EchoSkillBot.csproj
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/EchoSkillBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.EchoSkillBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.EchoSkillBot</RootNamespace>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/SimpleRootBot.csproj
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/SimpleRootBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.SimpleRootBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.SimpleRootBot</RootNamespace>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DialogRootBot.csproj
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DialogRootBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.DialogRootBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.DialogRootBot</RootNamespace>
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DialogSkillBot.csproj
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DialogSkillBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.DialogSkillBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.DialogSkillBot</RootNamespace>
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.7.0" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/README.md
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/README.md
@@ -6,7 +6,7 @@ This bot has been created using the [Bot Framework](https://dev.botframework.com
 
 ## Prerequisites
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/README.md
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/RootBot.csproj
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/RootBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.RootBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.RootBot</RootNamespace>
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/TokenExchangeSkillHandler.cs
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/RootBot/TokenExchangeSkillHandler.cs
@@ -74,8 +74,16 @@ namespace Microsoft.BotBuilderSamples.SSORootBot
 
         private BotFrameworkSkill GetCallingSkill(ClaimsIdentity claimsIdentity)
         {
-            var botAppIdClaim = claimsIdentity.Claims?.FirstOrDefault(claim => claim.Type == AuthenticationConstants.AppIdClaim);
-            var appId = botAppIdClaim?.Value;
+            var version = claimsIdentity.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.VersionClaim)?.Value;
+            var appId = claimsIdentity.Claims?.FirstOrDefault(claim =>
+            {
+                if (version == "2.0")
+                {
+                    return claim.Type == AuthenticationConstants.AuthorizedParty;
+                }
+
+                return claim.Type == AuthenticationConstants.AppIdClaim;
+            })?.Value;
             if (string.IsNullOrWhiteSpace(appId))
             {
                 return null;

--- a/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/SkillBot/SkillBot.csproj
+++ b/samples/csharp_dotnetcore/82.skills-sso-cloudadapter/SkillBot/SkillBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.BotBuilderSamples.SkillBot</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.SkillBot</RootNamespace>
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Addresses # 3948
#minor

## Description
This PR updates the Skills samples to target .NET 8

## Specific Changes
- Updated the following samples to target .NET 8
  - 80.skills-simple-bot-to-bot
  - 81.skills-skilldialog
  - 82.skills-sso-cloudadapter
- README files updated to target .NET 8
- Fixed an issue with skills-sso-cloudadapter when obtaining the Skill ID from claims.

## Testing
These images show the updated bots working as expected.
80.skills-simple-bot-to-bot
![imagen](https://github.com/southworks/BotBuilder-Samples/assets/62260472/57d7592d-dbc7-4ed9-b935-7521b6f67eef)
81.skills-skilldialog
![imagen](https://github.com/southworks/BotBuilder-Samples/assets/62260472/98d4bacf-391b-4e35-a1ff-c6af49735b82)
82.skills-sso-cloudadapter
![imagen](https://github.com/southworks/BotBuilder-Samples/assets/62260472/16e4ff2a-c2fa-4b10-bd78-534d5fc47fcf)
