### PR TITLE
[#3948] Update dotnet samples to target .Net 8 - Advanced samples

### DIFF
--- a/samples/csharp_dotnetcore/01.console-echo/Console-EchoBot.csproj
+++ b/samples/csharp_dotnetcore/01.console-echo/Console-EchoBot.csproj
@@ -4,13 +4,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
   </ItemGroup>
 
 </Project>

--- a/samples/csharp_dotnetcore/01.console-echo/README.md
+++ b/samples/csharp_dotnetcore/01.console-echo/README.md
@@ -8,7 +8,7 @@ This sample shows a simple echo bot and demonstrates the bot working as a consol
 
 ## Prerequisites
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/16.proactive-messages/ProactiveBot.csproj
+++ b/samples/csharp_dotnetcore/16.proactive-messages/ProactiveBot.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/16.proactive-messages/README.md
+++ b/samples/csharp_dotnetcore/16.proactive-messages/README.md
@@ -15,7 +15,7 @@ all users who have previously messaged the bot.
 
 ## Prerequisites
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/17.multilingual-bot/MultiLingualBot.csproj
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/MultiLingualBot.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/17.multilingual-bot/README.md
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/README.md
@@ -19,7 +19,7 @@ The API uses the most modern neural machine translation technology, as well as o
 
 ## Prerequisites
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/19.custom-dialogs/Custom-Dialogs.csproj
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/Custom-Dialogs.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/19.custom-dialogs/README.md
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/README.md
@@ -8,7 +8,7 @@ BotFramework provides a built-in base class called `Dialog`. By subclassing `Dia
 
 ## Prerequisites
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/CoreBot-App-Insights.csproj
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/CoreBot-App-Insights.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -15,11 +15,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.7.0" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/README.md
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/README.md
@@ -21,7 +21,7 @@ and [Application Insights](https://docs.microsoft.com/azure/azure-monitor/app/cl
 
 ### Install .NET Core CLI
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/23.facebook-events/Facebook-Events-Bot.csproj
+++ b/samples/csharp_dotnetcore/23.facebook-events/Facebook-Events-Bot.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/23.facebook-events/README.md
+++ b/samples/csharp_dotnetcore/23.facebook-events/README.md
@@ -8,7 +8,7 @@ More information about configuring a bot for Facebook Messenger can be found her
 
 ## Prerequisites
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/42.scaleout/README.md
+++ b/samples/csharp_dotnetcore/42.scaleout/README.md
@@ -8,7 +8,7 @@ The custom storage solution is implemented against memory for testing purposes a
 
 ## Prerequisites
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/42.scaleout/ScaleoutBot.csproj
+++ b/samples/csharp_dotnetcore/42.scaleout/ScaleoutBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -9,8 +9,8 @@
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/PromptUsersForInput.csproj
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/PromptUsersForInput.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
     <PackageReference Include="Microsoft.Recognizers.Text" Version="1.3.2" />
     <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.3.2" />
   </ItemGroup>

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/README.md
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/README.md
@@ -6,7 +6,7 @@ The bot maintains user state to track the user's answers.
 
 ## Prerequisites
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version

--- a/samples/csharp_dotnetcore/47.inspection/Inspection.csproj
+++ b/samples/csharp_dotnetcore/47.inspection/Inspection.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/47.inspection/README.md
+++ b/samples/csharp_dotnetcore/47.inspection/README.md
@@ -12,7 +12,7 @@ More details are available [here](https://github.com/microsoft/BotFramework-Emul
 
 ## Prerequisites
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version


### PR DESCRIPTION
Addresses # 3948
#minor

## Description
This PR updates the Advanced samples to target .NET 8.

## Specific Changes
- Updated the following samples to target .NET 8
  - 01.console-echo
  - 16.proactive-messages
  - 17.multilingual-bot
  - 19.custom-dialogs
  - 21.corebot-app-insights
  - 23.facebook-events
  - 42.scaleout
  - 44.prompt-users-for-input
  - 47.inspection

## Testing
These images show the updated bots working as expected.
01.console-echo
![image](https://github.com/southworks/BotBuilder-Samples/assets/62260472/7d64afdd-2248-4828-91e7-191a7c9e465b)

16.proactive-messages
![image](https://github.com/southworks/BotBuilder-Samples/assets/62260472/6c4c68a9-d28e-4152-bc07-4602af0bc5ae)

17.multilingual-bot
![image](https://github.com/southworks/BotBuilder-Samples/assets/62260472/5e45f015-dfea-4bc6-b99e-615becf3ca56)

19.custom-dialogs
![image](https://github.com/southworks/BotBuilder-Samples/assets/62260472/f18d4c09-11fe-4c33-b40f-7a498d86e9b3)

21.corebot-app-insights
![image](https://github.com/southworks/BotBuilder-Samples/assets/62260472/5a3370b0-5a10-4a0c-a86d-e21b98520497)

23.facebook-events
![image](https://github.com/southworks/BotBuilder-Samples/assets/62260472/f27e6e53-c88f-4685-8635-e7938353331c)

42.scaleout
![image](https://github.com/southworks/BotBuilder-Samples/assets/62260472/5bb0305b-5e5b-4357-8f0a-09a54a0d0d9d)

44.prompt-users-for-input
![image](https://github.com/southworks/BotBuilder-Samples/assets/62260472/bd6bd446-ba94-4de9-9439-c7df26cbf89f)

47.inspection
![image](https://github.com/southworks/BotBuilder-Samples/assets/62260472/6d1203e8-010d-4b2a-ad83-b86ec68d7325)

