### PR TITLE
[#4009] Update samples to support latest Node version - JavaScript

### DIFF
--- a/samples/javascript_nodejs/01.console-echo/README.md
+++ b/samples/javascript_nodejs/01.console-echo/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/01.console-echo/package.json
+++ b/samples/javascript_nodejs/01.console-echo/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder-core": "~4.17.0",
+        "botbuilder-core": "~4.23.0",
         "dotenv": "^8.2.0",
         "path": "^0.12.7",
         "readline": "^1.3.0"

--- a/samples/javascript_nodejs/02.echo-bot/README.md
+++ b/samples/javascript_nodejs/02.echo-bot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16"
+      "defaultValue": "NODE|20-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16"
+      "defaultValue": "NODE|20-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/package.json
+++ b/samples/javascript_nodejs/02.echo-bot/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
+        "botbuilder": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/03.welcome-users/README.md
+++ b/samples/javascript_nodejs/03.welcome-users/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/03.welcome-users/package.json
+++ b/samples/javascript_nodejs/03.welcome-users/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
+        "botbuilder": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/05.multi-turn-prompt/README.md
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/05.multi-turn-prompt/package.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
-        "botbuilder-dialogs": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botbuilder-dialogs": "~4.23.0",
         "dotenv": "^8.2.0",
         "path": "^0.12.7",
         "restify": "~10.0.0"

--- a/samples/javascript_nodejs/06.using-cards/README.md
+++ b/samples/javascript_nodejs/06.using-cards/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/06.using-cards/package.json
+++ b/samples/javascript_nodejs/06.using-cards/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
-        "botbuilder-dialogs": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botbuilder-dialogs": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/07.using-adaptive-cards/README.md
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/07.using-adaptive-cards/package.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
+        "botbuilder": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/08.suggested-actions/README.md
+++ b/samples/javascript_nodejs/08.suggested-actions/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/08.suggested-actions/package.json
+++ b/samples/javascript_nodejs/08.suggested-actions/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
+        "botbuilder": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/12.customQABot/README.md
+++ b/samples/javascript_nodejs/12.customQABot/README.md
@@ -9,7 +9,7 @@ This bot has been created using the [Bot Framework SDK][BF], it shows how to cre
 ## Prerequisites
 - This project requires a [Language service resource](https://aka.ms/create-language-resource) with Custom question answering enabled.
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/12.customQABot/package.json
+++ b/samples/javascript_nodejs/12.customQABot/package.json
@@ -16,8 +16,8 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "~4.22.1",
-    "botbuilder-ai": "~4.22.1",
+    "botbuilder": "~4.23.0",
+    "botbuilder-ai": "~4.23.0",
     "dotenv": "^8.2.0",
     "restify": "~10.0.0"
   },

--- a/samples/javascript_nodejs/13.core-bot/README.md
+++ b/samples/javascript_nodejs/13.core-bot/README.md
@@ -17,7 +17,7 @@ This sample **requires** prerequisites in order to run.
 
 This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to implement language understanding.
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16"
+      "defaultValue": "NODE|20-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16"
+      "defaultValue": "NODE|20-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/package.json
+++ b/samples/javascript_nodejs/13.core-bot/package.json
@@ -17,10 +17,10 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.22.1",
-        "botbuilder-ai": "~4.22.1",
-        "botbuilder-dialogs": "~4.22.1",
-        "botbuilder-testing": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botbuilder-ai": "~4.23.0",
+        "botbuilder-dialogs": "~4.23.0",
+        "botbuilder-testing": "~4.23.0",
         "dotenv": "^8.2.0",
         "moment-timezone": "~0.5.33",
         "restify": "~10.0.0"

--- a/samples/javascript_nodejs/15.handling-attachments/README.md
+++ b/samples/javascript_nodejs/15.handling-attachments/README.md
@@ -9,7 +9,7 @@ upload files to Teams from a bot and how to receive a file sent to a bot as an a
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/15.handling-attachments/package.json
+++ b/samples/javascript_nodejs/15.handling-attachments/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "axios": "^0.21.2",
-    "botbuilder": "~4.22.1",
+    "botbuilder": "~4.23.0",
     "dotenv": "^8.2.0",
     "restify": "~10.0.0"
   },

--- a/samples/javascript_nodejs/16.proactive-messages/README.md
+++ b/samples/javascript_nodejs/16.proactive-messages/README.md
@@ -15,7 +15,7 @@ all users who have previously messaged the bot.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/16.proactive-messages/package.json
+++ b/samples/javascript_nodejs/16.proactive-messages/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
-        "botbuilder-dialogs": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botbuilder-dialogs": "~4.23.0",
         "dotenv": "^8.2.0",
         "fetch-ponyfill": "^7.0.0",
         "moment": "^2.29.1",

--- a/samples/javascript_nodejs/17.multilingual-bot/README.md
+++ b/samples/javascript_nodejs/17.multilingual-bot/README.md
@@ -21,7 +21,7 @@ The API uses the most modern neural machine translation technology, as well as o
 
 This sample **requires** prerequisites in order to run.
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/17.multilingual-bot/package.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
+        "botbuilder": "~4.23.0",
         "dotenv": "^8.2.0",
         "node-fetch": "^2.6.0",
         "restify": "~10.0.0"

--- a/samples/javascript_nodejs/18.bot-authentication/README.md
+++ b/samples/javascript_nodejs/18.bot-authentication/README.md
@@ -10,7 +10,7 @@ NOTE: Microsoft Teams currently differs slightly in the way auth is integrated w
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/18.bot-authentication/package.json
+++ b/samples/javascript_nodejs/18.bot-authentication/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
-        "botbuilder-dialogs": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botbuilder-dialogs": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/19.custom-dialogs/README.md
+++ b/samples/javascript_nodejs/19.custom-dialogs/README.md
@@ -8,7 +8,7 @@ BotFramework provides a built-in base class called `Dialog`. By subclassing `Dia
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/19.custom-dialogs/package.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
-        "botbuilder-dialogs": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botbuilder-dialogs": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/21.corebot-app-insights/README.md
+++ b/samples/javascript_nodejs/21.corebot-app-insights/README.md
@@ -19,7 +19,7 @@ This sample **requires** prerequisites in order to run.
 This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to implement language understanding
 and [Application Insights](https://docs.microsoft.com/azure/azure-monitor/app/cloudservices), an extensible Application Performance Management (APM) service for web developers on multiple platforms.
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/21.corebot-app-insights/package.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/package.json
@@ -17,10 +17,10 @@
   "license": "MIT",
   "dependencies": {
     "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-    "botbuilder": "~4.22.1",
-    "botbuilder-ai": "~4.22.1",
-    "botbuilder-applicationinsights": "~4.22.1",
-    "botbuilder-dialogs": "~4.22.1",
+    "botbuilder": "~4.23.0",
+    "botbuilder-ai": "~4.23.0",
+    "botbuilder-applicationinsights": "~4.23.0",
+    "botbuilder-dialogs": "~4.23.0",
     "dotenv": "^8.2.0",
     "path": "^0.12.7",
     "restify": "~10.0.0"

--- a/samples/javascript_nodejs/23.facebook-events/README.md
+++ b/samples/javascript_nodejs/23.facebook-events/README.md
@@ -8,7 +8,7 @@ More information about configuring a bot for Facebook Messenger can be found her
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/23.facebook-events/package.json
+++ b/samples/javascript_nodejs/23.facebook-events/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
-        "botbuilder-dialogs": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botbuilder-dialogs": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/README.md
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/README.md
@@ -11,7 +11,7 @@ application setup for use in Azure Bot Service. The [scopes](https://developer.m
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/package.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/package.json
@@ -17,8 +17,8 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "~2.0.0",
-        "botbuilder": "~4.22.1",
-        "botbuilder-dialogs": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botbuilder-dialogs": "~4.23.0",
         "dotenv": "^8.2.0",
         "isomorphic-fetch": "^3.0.0",
         "restify": "~10.0.0"

--- a/samples/javascript_nodejs/43.complex-dialog/README.md
+++ b/samples/javascript_nodejs/43.complex-dialog/README.md
@@ -4,7 +4,7 @@ This sample creates a complex conversation with dialogs.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/43.complex-dialog/package.json
+++ b/samples/javascript_nodejs/43.complex-dialog/package.json
@@ -12,8 +12,8 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
-        "botbuilder-dialogs": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botbuilder-dialogs": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/44.prompt-for-user-input/README.md
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/README.md
@@ -6,7 +6,7 @@ The bot maintains user state to track the user's answers.
 
 ## Prerequisites
 
-- Node.js version 16.16.0 or higher.
+- Node.js version 18 or higher.
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/44.prompt-for-user-input/package.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-suite": "1.1.4",
-        "botbuilder": "~4.22.1",
+        "botbuilder": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/45.state-management/README.md
+++ b/samples/javascript_nodejs/45.state-management/README.md
@@ -6,7 +6,7 @@ The bot maintains user state to track the user's answers.
 
 ## Prerequisites
 
-- Node.js version 16.16.0 or higher.
+- Node.js version 18 or higher.
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/45.state-management/package.json
+++ b/samples/javascript_nodejs/45.state-management/package.json
@@ -12,7 +12,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
+        "botbuilder": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/47.inspection/README.md
+++ b/samples/javascript_nodejs/47.inspection/README.md
@@ -12,7 +12,7 @@ More details are available [here](https://github.com/microsoft/BotFramework-Emul
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/47.inspection/package.json
+++ b/samples/javascript_nodejs/47.inspection/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
+        "botbuilder": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/48.customQABot-all-features/README.md
+++ b/samples/javascript_nodejs/48.customQABot-all-features/README.md
@@ -13,7 +13,7 @@ This bot was created using [Bot Framework][BF].
 
 ## Prerequisites
 - This project requires a [Language resource](https://aka.ms/create-language-resource) with Custom question answering enabled.
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/48.customQABot-all-features/package.json
+++ b/samples/javascript_nodejs/48.customQABot-all-features/package.json
@@ -16,9 +16,9 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "~4.22.1",
-    "botbuilder-ai": "~4.22.1",
-    "botbuilder-dialogs": "~4.22.1",
+    "botbuilder": "~4.23.0",
+    "botbuilder-ai": "~4.23.0",
+    "botbuilder-dialogs": "~4.23.0",
     "dotenv": "^8.2.0",
     "restify": "~10.0.0"
   },

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/README.md
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/package.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
-        "botframework-connector": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botframework-connector": "~4.23.0",
         "dotenv": "~8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/package.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
-        "botframework-connector": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botframework-connector": "~4.23.0",
         "dotenv": "~8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/81.skills-skilldialog/README.md
+++ b/samples/javascript_nodejs/81.skills-skilldialog/README.md
@@ -6,7 +6,7 @@ This bot has been created using the [Bot Framework](https://dev.botframework.com
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher.
+- [Node.js](https://nodejs.org) version 18 or higher.
 
     ```bash
     # Determine node version.

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/package.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
-        "botbuilder-dialogs": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botbuilder-dialogs": "~4.23.0",
         "dotenv": "~8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/package.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/package.json
@@ -17,9 +17,9 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "~1.1.4",
-        "botbuilder": "~4.22.1",
-        "botbuilder-ai": "~4.22.1",
-        "botbuilder-dialogs": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botbuilder-ai": "~4.23.0",
+        "botbuilder-dialogs": "~4.23.0",
         "dotenv": "~8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/README.md
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher.
+- [Node.js](https://nodejs.org) version 18 or higher.
 
     ```bash
     # Determine node version.

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/package.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
-        "botbuilder-dialogs": "~4.22.1",
-        "botbuilder-lg": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botbuilder-dialogs": "~4.23.0",
+        "botbuilder-lg": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/package.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/package.json
@@ -17,11 +17,11 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.22.1",
-        "botbuilder-ai": "~4.22.1",
-        "botbuilder-dialogs": "~4.22.1",
-        "botbuilder-testing": "~4.22.1",
-        "botbuilder-lg": "~4.22.1",
+        "botbuilder": "~4.23.0",
+        "botbuilder-ai": "~4.23.0",
+        "botbuilder-dialogs": "~4.23.0",
+        "botbuilder-testing": "~4.23.0",
+        "botbuilder-lg": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/README.md
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16"
+      "defaultValue": "NODE|20-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16"
+      "defaultValue": "NODE|20-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/package.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.22.1",
+        "botbuilder": "~4.23.0",
         "dotenv": "^8.2.0",
         "math-random": "^2.0.1",
         "restify": "~10.0.0"

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/README.md
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com/), 
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
 ```bash
 # determine node version

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -176,7 +176,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -194,7 +194,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -194,7 +194,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -151,7 +151,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16"
+      "defaultValue": "NODE|20-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16"
+      "defaultValue": "NODE|20-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/package.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/package.json
@@ -19,7 +19,7 @@
         "@azure/identity": "^3.3.0",
         "@azure/keyvault-certificates": "^4.7.0",
         "@azure/keyvault-secrets": "^4.7.0",
-        "botbuilder": "~4.22.1",
+        "botbuilder": "~4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/85.bot-authentication-sni/README.md
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com/), 
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
 ```bash
 # determine node version

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "16.20.2"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS.20"
+      "defaultValue": "NODE|20-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16.20"
+      "defaultValue": "NODE|20-LTS.20"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "16.20.2"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16.20"
+      "defaultValue": "NODE|20-LTS.20"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS.20"
+      "defaultValue": "NODE|20-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/package.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/package.json
@@ -19,7 +19,7 @@
         "@azure/identity": "^3.3.0",
         "@azure/keyvault-certificates": "^4.7.0",
         "@azure/keyvault-secrets": "^4.7.0",
-        "botbuilder": "^4.22.1",
+        "botbuilder": "^4.23.0",
         "dotenv": "^8.2.0",
         "restify": "~10.0.0"
     },

--- a/samples/javascript_nodejs/86.echo-proxy-bot/README.md
+++ b/samples/javascript_nodejs/86.echo-proxy-bot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 16.16.0 or higher
+- [Node.js](https://nodejs.org) version 18 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16"
+      "defaultValue": "NODE|20-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~16"
+              "value": "~20"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|16"
+      "defaultValue": "NODE|20-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~16"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/86.echo-proxy-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~22"
+                      "value": "~20"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/86.echo-proxy-bot/package.json
+++ b/samples/javascript_nodejs/86.echo-proxy-bot/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies": {
         "@azure/msal-node": "^1.18.4",
-        "botbuilder": "~4.22.1",
+        "botbuilder": "~4.23.0",
         "dotenv": "^8.2.0",
         "node-global-proxy": "^1.0.1",
         "restify": "~10.0.0"


### PR DESCRIPTION
Fixes # 4009

## Description
This PR updates the ARM templates of the JavaScript samples to use Node 20 as default.

## Proposed Changes
- Updated Node to version 20 in all ARM templates.
- Updated Node required version in README files.

## Testing
These images show the resources created in Azure and a bot working after the deployment.
![image](https://github.com/user-attachments/assets/50a74ca8-8a6a-4303-93f6-9d1ffeb61f8f)
