### PR TITLE
Update samples to support Node 22 version - Typescript

### DIFF
--- a/samples/typescript_nodejs/00.empty-bot/deploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/00.empty-bot/deploymentTemplates/DeployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/00.empty-bot/deploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/00.empty-bot/deploymentTemplates/DeployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/00.empty-bot/tsconfig.json
+++ b/samples/typescript_nodejs/00.empty-bot/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "es2016",
-    "module": "commonjs",
+    "module": "NodeNext",
     "outDir": "./lib",
     "rootDir": "./src",
     "sourceMap": true,

--- a/samples/typescript_nodejs/01.console-echo/tsconfig.json
+++ b/samples/typescript_nodejs/01.console-echo/tsconfig.json
@@ -3,7 +3,7 @@
     "composite": true,
     "declaration": true,
     "target": "es2016",
-    "module": "commonjs",
+    "module": "NodeNext",
     "outDir": "./lib",
     "rootDir": "./src",
     "sourceMap": true,

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/typescript_nodejs/02.echo-bot/tsconfig.json
+++ b/samples/typescript_nodejs/02.echo-bot/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "es2016",
-    "module": "commonjs",
+    "module": "NodeNext",
     "outDir": "./lib",
     "rootDir": "./src",
     "sourceMap": true,

--- a/samples/typescript_nodejs/03.welcome-users/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/03.welcome-users/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/03.welcome-users/tsconfig.json
+++ b/samples/typescript_nodejs/03.welcome-users/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "es2016",
-    "module": "commonjs",
+    "module": "NodeNext",
     "outDir": "./lib",
     "rootDir": "./src",
     "sourceMap": true,

--- a/samples/typescript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/05.multi-turn-prompt/tsconfig.json
+++ b/samples/typescript_nodejs/05.multi-turn-prompt/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "es2016",
-    "module": "commonjs",
+    "module": "NodeNext",
     "outDir": "./lib",
     "rootDir": "./src",
     "sourceMap": true,

--- a/samples/typescript_nodejs/06.using-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/06.using-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/06.using-cards/tsconfig.json
+++ b/samples/typescript_nodejs/06.using-cards/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "es2016",
-    "module": "commonjs",
+    "module": "NodeNext",
     "outDir": "./lib",
     "rootDir": "./src",
     "sourceMap": true,

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",

--- a/samples/typescript_nodejs/13.core-bot/tsconfig.json
+++ b/samples/typescript_nodejs/13.core-bot/tsconfig.json
@@ -3,7 +3,7 @@
     "composite": true,
     "declaration": true,
     "target": "es2016",
-    "module": "commonjs",
+    "module": "NodeNext",
     "outDir": "./lib",
     "rootDir": "./src",
     "resolveJsonModule": true,

--- a/samples/typescript_nodejs/16.proactive-messages/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/typescript_nodejs/16.proactive-messages/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/typescript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/typescript_nodejs/16.proactive-messages/tsconfig.json
+++ b/samples/typescript_nodejs/16.proactive-messages/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "es2016",
-    "module": "commonjs",
+    "module": "NodeNext",
     "outDir": "./lib",
     "rootDir": "./src",
     "sourceMap": true,


### PR DESCRIPTION
#minor

## Description
This PR updates the ARM templates of the Typescript samples to use Node 22 as default.

## Proposed Changes
- Updated Node to version 22 in all ARM templates for Windows and Linux.
- Updated tsconfig in all Typescript samples, _commonJs_ to _NodeNext_

## Testing
This image shows the bot working after the deployment.
![image](https://github.com/user-attachments/assets/96d5f551-6b92-4dfc-ba51-aa5adc981fa2)

This image shows the error when using commonjs.
![image](https://github.com/user-attachments/assets/671423eb-8345-49ac-b066-4d19c14ffba9)


